### PR TITLE
Fix gly_hclust device leak when using ggdendro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .quarto
 docs
 /.cursor/
+.worktrees/
 inst/doc
 /doc/
 /Meta/

--- a/R/hclust.R
+++ b/R/hclust.R
@@ -184,11 +184,18 @@ gly_hclust_ <- function(
   # 3. Try to create dendrogram data using ggdendro if available
   if (requireNamespace("ggdendro", quietly = TRUE)) {
     tryCatch({
-      # Prevent opening graphics device window on macOS using withr
-      withr::with_options(
-        list(device = function() grDevices::pdf(NULL)),
-        dendro_data <- ggdendro::dendro_data(hclust_res)
-      )
+      # Use a temporary device for ggdendro and always close it
+      grDevices::pdf(NULL)
+      dev_id <- grDevices::dev.cur()
+      on.exit({
+        devices <- grDevices::dev.list()
+        devices <- if (is.null(devices)) integer(0) else as.integer(devices)
+        if (dev_id %in% devices) {
+          grDevices::dev.off(dev_id)
+        }
+      }, add = TRUE)
+
+      dendro_data <- ggdendro::dendro_data(hclust_res)
       tidy_result$dendrogram <- tibble::as_tibble(dendro_data$segments)
       tidy_result$labels <- tibble::as_tibble(dendro_data$labels)
     }, error = function(e) {

--- a/tests/testthat/test-hclust.R
+++ b/tests/testthat/test-hclust.R
@@ -1,3 +1,21 @@
+test_that("gly_hclust does not leak graphics devices when ggdendro is available", {
+  testthat::skip_if_not_installed("ggdendro")
+
+  open_devices <- grDevices::dev.list()
+  open_devices <- if (is.null(open_devices)) integer(0) else as.integer(open_devices)
+
+  exp_subset <- test_gp_exp |>
+    glyexp::slice_sample_var(n = 5) |>
+    glyexp::slice_sample_obs(n = 5)
+
+  suppressMessages(gly_hclust(exp_subset, on = "sample", k_values = c(2)))
+
+  after_devices <- grDevices::dev.list()
+  after_devices <- if (is.null(after_devices)) integer(0) else as.integer(after_devices)
+
+  expect_identical(after_devices, open_devices)
+})
+
 test_that("gly_hclust works with basic parameters (default: cluster variables)", {
   # Use a subset of test data for faster testing
   exp_subset <- test_gp_exp |>


### PR DESCRIPTION
## Summary
- close the temporary graphics device opened for `ggdendro::dendro_data()`
- add regression test to ensure `gly_hclust()` does not leak devices

## Testing
- Rscript -e "devtools::test(filter = 'hclust')"
- Rscript -e "devtools::test()"

Fixes #2
