### PR TITLE
feat: add meta_data to all glystats results

### DIFF
--- a/R/anova.R
+++ b/R/anova.R
@@ -37,7 +37,7 @@
 #' for variables with significant main effects (p_adj < 0.05).
 #'
 #' @returns
-#' A list containing two elements:
+#' A list containing three elements:
 #'   - `tidy_result`: A list containing:
 #'     - `main_test`: A tibble with ANOVA results containing the following columns:
 #'       - `variable`: Variable name
@@ -58,6 +58,7 @@
 #'   - `raw_result`: A list containing:
 #'     - `main_test`: A list of raw `aov` model objects.
 #'     - `post_hoc_test`: A list of raw `TukeyHSD` objects.
+#'   - `meta_data`: A list containing metadata from the input experiment.
 #'
 #' @seealso [stats::aov()], [stats::TukeyHSD()]
 #' @export
@@ -99,6 +100,8 @@ gly_anova <- function(
     exp,
     add_info
   )
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
   result
 }
 
@@ -445,7 +448,7 @@ gly_ancova_ <- function(
 #' for variables with significant main effects (p_adj < 0.05).
 #'
 #' @returns
-#' A list containing two elements:
+#' A list containing three elements:
 #'   - `tidy_result`: A list containing:
 #'     - `main_test`: A tibble with Kruskal-Wallis test results containing the following columns:
 #'       - `variable`: Variable name
@@ -464,6 +467,7 @@ gly_ancova_ <- function(
 #'   - `raw_result`: A list containing:
 #'     - `main_test`: A list of raw `kruskal.test` objects.
 #'     - `post_hoc_test`: A list of raw `dunnTest` objects.
+#'   - `meta_data`: A list containing metadata from the input experiment.
 #'
 #' @seealso [stats::kruskal.test()], [FSA::dunnTest()]
 #' @export
@@ -508,6 +512,8 @@ gly_kruskal <- function(
     exp,
     add_info
   )
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
   result
 }
 

--- a/R/cc.R
+++ b/R/cc.R
@@ -52,12 +52,13 @@
 #' 1. Perform consensus clustering for k = 2 to max_k using ConsensusClusterPlus
 #' 2. Return cluster assignments for all k values in long format
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with consensus clustering results containing the following columns:
 #'    - `variable` or `sample`: Variable or sample name (depending on `on` parameter)
 #'    - `k`: Number of clusters
 #'    - `cluster`: Cluster assignment for the corresponding k
 #'  - `raw_result`: The raw ConsensusClusterPlus object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_cc_res` and `glystats_res`.
 #'
 #' @seealso [ConsensusClusterPlus::ConsensusClusterPlus()]
@@ -94,6 +95,10 @@ gly_consensus_clustering <- function(
     ...
   )
   result <- .process_results_add_info(result, exp, add_info)
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/cor.R
+++ b/R/cor.R
@@ -36,7 +36,7 @@
 #' **Multiple Testing Correction:**
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with correlation results containing the following columns:
 #'    - `variable1` or `sample1`: First element of the pair (depending on `on` parameter)
 #'    - `variable2` or `sample2`: Second element of the pair (depending on `on` parameter)
@@ -44,6 +44,7 @@
 #'    - `p_val`: Raw p-value from correlation test
 #'    - `p_adj`: Adjusted p-value (if p_adj_method is not NULL)
 #'  - `raw_result`: The raw rcorr object from Hmisc::rcorr()
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_cor_res` and `glystats_res`.
 #'
 #' @seealso [Hmisc::rcorr()], [stats::cor()]
@@ -69,7 +70,12 @@ gly_cor <- function(
   expr_mat <- glyexp::get_expr_mat(exp)
 
   # Call the underlying API
-  gly_cor_(expr_mat, on, method, p_adj_method, ...)
+  result <- gly_cor_(expr_mat, on, method, p_adj_method, ...)
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_cor

--- a/R/cox.R
+++ b/R/cox.R
@@ -28,7 +28,7 @@
 #'
 #' P-values are adjusted by Benjamini-Hochberg method by default.
 #'
-#' @returns A list with two elements:
+#' @returns A list with three elements:
 #'  - `tidy_result`: A tibble with Cox model results containing the following columns:
 #'    - `variable`: Variable name
 #'    - `coefficient`: Regression coefficient (log hazard ratio)
@@ -38,6 +38,7 @@
 #'    - `hr`: Hazard ratio (exp(coefficient))
 #'    - `p_adj`: Adjusted p-value (if p_adj_method is not NULL)
 #'  - `raw_result`: A list of raw `coxph` model objects.
+#'  - `meta_data`: A list containing metadata from the input experiment
 #'
 #' @seealso [survival::coxph()], [survival::Surv()]
 #' @export
@@ -69,6 +70,10 @@ gly_cox <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/enrich.R
+++ b/R/enrich.R
@@ -27,7 +27,7 @@
 #' - `clusterProfiler` for enrichment analysis
 #' - `org.Hs.eg.db` for human gene annotation or other OrgDb packages
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with enrichment results containing the following columns:
 #'    - `id`: Term ID
 #'    - `description`: Term description
@@ -39,6 +39,7 @@
 #'    - `gene_id`: Gene IDs in the term (separated by "/")
 #'    - `count`: Number of genes in the term
 #'  - `raw_result`: The raw clusterProfiler enrichResult object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_go_ora_res` and `glystats_res`.
 #' @seealso [clusterProfiler::enrichGO()]
 #' @export
@@ -55,7 +56,7 @@ gly_enrich_go <- function(
   rlang::check_installed("clusterProfiler")
   checkmate::assert_logical(add_info, len = 1)
   proteins <- .extract_uniprot_from_exp(exp)
-  gly_enrich_go_(
+  result <- gly_enrich_go_(
     proteins,
     orgdb = orgdb,
     ont = ont,
@@ -64,6 +65,11 @@ gly_enrich_go <- function(
     p_cutoff = p_cutoff,
     q_cutoff = q_cutoff
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_enrich_go
@@ -131,7 +137,7 @@ gly_enrich_go_ <- function(
 #' These functions require the following packages to be installed:
 #' - `clusterProfiler` for enrichment analysis
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with enrichment results containing the following columns:
 #'    - `id`: Term ID (e.g., hsa:XXXXX)
 #'    - `description`: Term description
@@ -143,6 +149,7 @@ gly_enrich_go_ <- function(
 #'    - `gene_id`: Gene IDs in the term (separated by "/")
 #'    - `count`: Number of genes in the term
 #'  - `raw_result`: The raw clusterProfiler enrichResult object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_kegg_ora_res` and `glystats_res`.
 #' @seealso [clusterProfiler::enrichKEGG()]
 #' @export
@@ -158,7 +165,7 @@ gly_enrich_kegg <- function(
   rlang::check_installed("clusterProfiler")
   checkmate::assert_logical(add_info, len = 1)
   proteins <- .extract_uniprot_from_exp(exp)
-  gly_enrich_kegg_(
+  result <- gly_enrich_kegg_(
     proteins,
     organism = organism,
     universe = universe,
@@ -166,6 +173,11 @@ gly_enrich_kegg <- function(
     p_cutoff = p_cutoff,
     q_cutoff = q_cutoff
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_enrich_kegg
@@ -234,7 +246,7 @@ gly_enrich_kegg_ <- function(
 #' - `ReactomePA` for enrichment analysis
 #' - `org.Hs.eg.db` for human gene annotation or other OrgDb packages
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with enrichment results containing the following columns:
 #'    - `id`: Term ID (e.g., R-HSA-XXXXXX)
 #'    - `description`: Term description
@@ -246,6 +258,7 @@ gly_enrich_kegg_ <- function(
 #'    - `gene_id`: Gene IDs in the term (separated by "/")
 #'    - `count`: Number of genes in the term
 #'  - `raw_result`: The raw ReactomePA enrichPathway result object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_reactome_ora_res` and `glystats_res`.
 #' @seealso [ReactomePA::enrichPathway()]
 #' @export
@@ -264,7 +277,7 @@ gly_enrich_reactome <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   proteins <- .extract_uniprot_from_exp(exp)
-  gly_enrich_reactome_(
+  result <- gly_enrich_reactome_(
     proteins,
     orgdb = orgdb,
     organism = organism,
@@ -273,6 +286,11 @@ gly_enrich_reactome <- function(
     p_cutoff = p_cutoff,
     q_cutoff = q_cutoff
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_enrich_reactome
@@ -349,7 +367,7 @@ gly_enrich_reactome_ <- function(
 #' - `clusterProfiler` for enrichment analysis and ID conversion
 #' - `org.Hs.eg.db` for human gene annotation or other OrgDb packages
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with enrichment results containing the following columns:
 #'    - `id`: Term ID (e.g., WPXXXXX)
 #'    - `description`: Term description
@@ -361,6 +379,7 @@ gly_enrich_reactome_ <- function(
 #'    - `gene_id`: Gene IDs in the term (separated by "/")
 #'    - `count`: Number of genes in the term
 #'  - `raw_result`: The raw clusterProfiler enrichResult object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_wikipathways_ora_res` and `glystats_res`.
 #' @seealso [clusterProfiler::enrichWP()]
 #' @export
@@ -378,7 +397,7 @@ gly_enrich_wikipathways <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   proteins <- .extract_uniprot_from_exp(exp)
-  gly_enrich_wikipathways_(
+  result <- gly_enrich_wikipathways_(
     proteins,
     organism = organism,
     orgdb = orgdb,
@@ -387,6 +406,11 @@ gly_enrich_wikipathways <- function(
     p_cutoff = p_cutoff,
     q_cutoff = q_cutoff
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_enrich_wikipathways
@@ -464,7 +488,7 @@ gly_enrich_wikipathways_ <- function(
 #' - `DOSE` for enrichment analysis
 #' - `org.Hs.eg.db` for human gene annotation or other OrgDb packages
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with enrichment results containing the following columns:
 #'    - `id`: Term ID (e.g., DOID:XXXX)
 #'    - `description`: Term description
@@ -476,6 +500,7 @@ gly_enrich_wikipathways_ <- function(
 #'    - `gene_id`: Gene IDs in the term (separated by "/")
 #'    - `count`: Number of genes in the term
 #'  - `raw_result`: The raw DOSE enrichResult object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_do_ora_res` and `glystats_res`.
 #' @seealso [DOSE::enrichDO()]
 #' @export
@@ -495,7 +520,7 @@ gly_enrich_do <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   proteins <- .extract_uniprot_from_exp(exp)
-  gly_enrich_do_(
+  result <- gly_enrich_do_(
     proteins,
     ont = ont,
     organism = organism,
@@ -505,6 +530,11 @@ gly_enrich_do <- function(
     p_cutoff = p_cutoff,
     q_cutoff = q_cutoff
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_enrich_do
@@ -581,7 +611,7 @@ gly_enrich_do_ <- function(
 #' - `DOSE` for enrichment analysis
 #' - `org.Hs.eg.db` for human gene annotation or other OrgDb packages
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with enrichment results containing the following columns:
 #'    - `id`: Term ID
 #'    - `description`: Term description
@@ -593,6 +623,7 @@ gly_enrich_do_ <- function(
 #'    - `gene_id`: Gene IDs in the term (separated by "/")
 #'    - `count`: Number of genes in the term
 #'  - `raw_result`: The raw DOSE enrichResult object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_ncg_ora_res` and `glystats_res`.
 #' @seealso [DOSE::enrichNCG()]
 #' @export
@@ -610,7 +641,7 @@ gly_enrich_ncg <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   proteins <- .extract_uniprot_from_exp(exp)
-  gly_enrich_ncg_(
+  result <- gly_enrich_ncg_(
     proteins,
     orgdb = orgdb,
     universe = universe,
@@ -618,6 +649,11 @@ gly_enrich_ncg <- function(
     p_cutoff = p_cutoff,
     q_cutoff = q_cutoff
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_enrich_ncg
@@ -690,7 +726,7 @@ gly_enrich_ncg_ <- function(
 #' - `DOSE` for enrichment analysis
 #' - `org.Hs.eg.db` for human gene annotation or other OrgDb packages
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #'  - `tidy_result`: A tibble with enrichment results containing the following columns:
 #'    - `id`: Term ID
 #'    - `description`: Term description
@@ -702,6 +738,7 @@ gly_enrich_ncg_ <- function(
 #'    - `gene_id`: Gene IDs in the term (separated by "/")
 #'    - `count`: Number of genes in the term
 #'  - `raw_result`: The raw DOSE enrichResult object
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_dgn_ora_res` and `glystats_res`.
 #' @seealso [DOSE::enrichDGN()]
 #' @export
@@ -719,7 +756,7 @@ gly_enrich_dgn <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   proteins <- .extract_uniprot_from_exp(exp)
-  gly_enrich_dgn_(
+  result <- gly_enrich_dgn_(
     proteins,
     orgdb = orgdb,
     universe = universe,
@@ -727,6 +764,11 @@ gly_enrich_dgn <- function(
     p_cutoff = p_cutoff,
     q_cutoff = q_cutoff
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
+  result
 }
 
 #' @rdname gly_enrich_dgn

--- a/R/fold-change.R
+++ b/R/fold-change.R
@@ -24,10 +24,13 @@
 #' `gly_fold_change_()` is the underlying API that works with matrices and factor vectors directly,
 #' providing more flexibility for users who don't use the glyexp package.
 #'
-#' @returns A tibble with fold change results containing the following columns:
-#'   - `variable`: Variable name
-#'   - `log2fc`: Log2 fold change (log2(group2_mean / group1_mean))
-#'   If more than two groups, two additional columns `ref_group` and `test_group` will be added.
+#' @returns A list with three elements:
+#'  - `tidy_result`: A tibble with fold change results containing the following columns:
+#'    - `variable`: Variable name
+#'    - `log2fc`: Log2 fold change (log2(group2_mean / group1_mean))
+#'    If more than two groups, two additional columns `ref_group` and `test_group` will be added.
+#'  - `raw_result`: The raw result (same as tidy_result for this function)
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' @export
 gly_fold_change <- function(exp, group_col = "group", add_info = TRUE) {
   checkmate::assert_class(exp, "glyexp_experiment")
@@ -47,10 +50,20 @@ gly_fold_change <- function(exp, group_col = "group", add_info = TRUE) {
   expr_mat <- exp$expr_mat
 
   # Call the underlying API
-  result <- gly_fold_change_(expr_mat, groups)
+  tidy_result <- gly_fold_change_(expr_mat, groups)
 
   # Process results with add_info logic
-  .process_results_add_info(result, exp, add_info)
+  tidy_result <- .process_results_add_info(tidy_result, exp, add_info)
+
+  # Build result list
+  result <- list(
+    tidy_result = tidy_result,
+    raw_result = tidy_result,
+    meta_data = glyexp::get_meta_data(exp)
+  )
+  class(result) <- c("glystats_fc_res", "glystats_res", class(result))
+
+  result
 }
 
 #' @rdname gly_fold_change

--- a/R/hclust.R
+++ b/R/hclust.R
@@ -61,6 +61,7 @@
 #'      - `x`, `y`: Position coordinates
 #'      - `label`: Label text
 #'  - `raw_result`: The raw hclust object from `stats::hclust()`
+#'  - `meta_data`: A list containing metadata from the input experiment
 #'
 #' @seealso [stats::hclust()], [stats::dist()], [stats::cutree()]
 #' @export
@@ -91,6 +92,10 @@ gly_hclust <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -37,11 +37,12 @@
 #' **Clustering Method:**
 #' K-means clustering is performed using `stats::kmeans()` with the specified parameters.
 #'
-#' @returns A list with two elements:
+#' @returns A list with three elements:
 #'  - `tidy_result`: A tibble with cluster assignments containing the following columns:
 #'    - `variable` or `sample`: Variable or sample name (depending on `on` parameter)
 #'    - `cluster`: Cluster assignment
 #'  - `raw_result`: The raw kmeans object from `stats::kmeans()`.
+#'  - `meta_data`: A list containing metadata from the input experiment
 #'
 #' @seealso [stats::kmeans()]
 #' @export
@@ -73,6 +74,10 @@ gly_kmeans <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/limma.R
+++ b/R/limma.R
@@ -67,7 +67,7 @@
 #' This function requires the following packages to be installed:
 #' - `limma` for linear model fitting and empirical Bayes moderation
 #'
-#' @returns A list with two elements:
+#' @returns A list with three elements:
 #'  - `tidy_result`: A tibble with limma results containing the following columns:
 #'    - `variable`: Variable name
 #'    - `log2fc`: Log2 fold change
@@ -80,6 +80,7 @@
 #'    - `test_group`: Test group
 #'
 #'  - `raw_result`: The raw limma fit object(s).
+#'  - `meta_data`: The meta data from the experiment object (only for `gly_limma()`).
 #' @seealso [limma::lmFit()], [limma::eBayes()], [limma::makeContrasts()]
 #' @export
 gly_limma <- function(
@@ -162,6 +163,10 @@ gly_limma <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/oplsda.R
+++ b/R/oplsda.R
@@ -52,6 +52,7 @@
 #'      - `perm_id`: Permutation ID (0 for original model, 1+ for permutations)
 #'      - Additional columns from the permutation test matrix (e.g., R2X, R2Y, Q2, etc.)
 #'  - `raw_result`: The raw ropls opls object from `ropls::opls()`
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' @seealso [ropls::opls()]
 #' @export
 gly_oplsda <- function(
@@ -97,6 +98,10 @@ gly_oplsda <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/pca.R
+++ b/R/pca.R
@@ -42,6 +42,7 @@
 #'      - `percent`: Percentage of variance explained
 #'      - `cumulative`: Cumulative percentage of variance explained
 #'  - `raw_result`: The raw prcomp object from `stats::prcomp()`
+#'  - `meta_data`: A list containing metadata from the experiment (only for [gly_pca()])
 #' @seealso [stats::prcomp()]
 #' @export
 gly_pca <- function(exp, center = TRUE, scale = TRUE, add_info = TRUE, ...) {
@@ -58,6 +59,10 @@ gly_pca <- function(exp, center = TRUE, scale = TRUE, add_info = TRUE, ...) {
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -49,6 +49,7 @@
 #'      - `perm_id`: Permutation ID (0 for original model, 1+ for permutations)
 #'      - Additional columns from the permutation test matrix (e.g., R2X, R2Y, Q2, etc.)
 #'  - `raw_result`: The raw ropls opls object from `ropls::opls()`
+#'  - `meta_data`: A list containing metadata from the input experiment
 #' @seealso [ropls::opls()]
 #' @export
 gly_plsda <- function(
@@ -90,6 +91,10 @@ gly_plsda <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/roc.R
+++ b/R/roc.R
@@ -40,7 +40,7 @@
 #' This function requires the `pROC` package to be installed for ROC curve computation.
 #'
 #' @returns
-#' A list with two elements:
+#' A list with three elements:
 #' - `tidy_result`: A list containing two tibbles:
 #'   - `auc`: A tibble containing AUC values for each variable with the following columns:
 #'     - `variable`: Variable name
@@ -53,6 +53,7 @@
 #'     - `specificity`: Specificity (True Negative Rate)
 #'     - `sensitivity`: Sensitivity (True Positive Rate)
 #' - `raw_result`: A list of `pROC` objects
+#' - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_roc_res` and `glystats_res`.
 #' @seealso [pROC::roc()], [pROC::coords()]
 #' @export
@@ -92,6 +93,10 @@ gly_roc <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/tsne.R
+++ b/R/tsne.R
@@ -22,12 +22,13 @@
 #' `gly_tsne_()` is the underlying API that works with matrices directly,
 #' providing more flexibility for users who don't use the glyexp package.
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #' - `tidy_result`: A tibble with t-SNE coordinates containing the following columns:
 #'   - `sample`: Sample name
 #'   - `tsne1`: First t-SNE dimension
 #'   - `tsne2`: Second t-SNE dimension
 #' - `raw_result`: The raw Rtsne object
+#' - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_tsne_res` and `glystats_res`.
 #' @seealso [Rtsne::Rtsne()]
 #' @export
@@ -43,6 +44,10 @@ gly_tsne <- function(exp, dims = 2, perplexity = 30, add_info = TRUE, ...) {
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/ttest.R
+++ b/R/ttest.R
@@ -30,7 +30,7 @@
 #' `gly_ttest_()` is the underlying API that works with matrices and factor vectors directly,
 #' providing more flexibility for users who don't use the glyexp package.
 #'
-#' @returns A list with two elements:
+#' @returns A list with three elements:
 #' - `tidy_result`: A tibble with t-test results containing the following columns:
 #'   - `variable`: Variable name
 #'   - `estimate`: Difference in group means (group2 - group1)
@@ -46,6 +46,7 @@
 #'   - `p_adj`: Adjusted p-value (if p_adj_method is not NULL)
 #'   - `log2fc`: Log2 fold change (log2(group2_mean / group1_mean))
 #' - `raw_result`: A list of `t.test` model objects
+#' - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_ttest_res` and `glystats_res`.
 #' @seealso [stats::t.test()]
 #' @export
@@ -91,6 +92,10 @@ gly_ttest <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 
@@ -167,7 +172,7 @@ gly_ttest_ <- function(
 #' providing more flexibility for users who don't use the glyexp package.
 #'
 #' @returns
-#' A list with two elements:
+#' A list with three elements:
 #' - `tidy_result`: A tibble with Wilcoxon test results containing the following columns:
 #'   - `variable`: Variable name
 #'   - `statistic`: Wilcoxon test statistic
@@ -178,6 +183,7 @@ gly_ttest_ <- function(
 #'   - `log2fc`: Log2 fold change (log2(group2_mean / group1_mean))
 #'   Additional columns from experiment metadata may be included if add_info = TRUE.
 #' - `raw_result`: A list of `wilcox.test` model objects
+#' - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_wilcox_res` and `glystats_res`.
 #'
 #' @seealso [stats::wilcox.test()]
@@ -229,6 +235,10 @@ gly_wilcox <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/umap.R
+++ b/R/umap.R
@@ -22,13 +22,14 @@
 #' `gly_umap_()` is the underlying API that works with matrices directly,
 #' providing more flexibility for users who don't use the glyexp package.
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #' - `tidy_result`: A tibble with UMAP coordinates containing the following columns:
 #'   - `sample`: Sample name
 #'   - `umap1`: First UMAP dimension
 #'   - `umap2`: Second UMAP dimension
 #'   - `umap3`, `umap4`, etc.: Additional UMAP dimensions (if n_components > 2)
 #' - `raw_result`: The raw UMAP result matrix
+#' - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_umap_res` and `glystats_res`.
 #' @seealso [uwot::umap()]
 #' @export
@@ -51,6 +52,10 @@ gly_umap <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/R/wgcna.R
+++ b/R/wgcna.R
@@ -47,7 +47,7 @@
 #' 3. Module membership calculation based on correlation with module eigengenes
 #' 4. Results formatting into standardized tibbles
 #'
-#' @return A list with two elements:
+#' @return A list with three elements:
 #' - `tidy_result`: A list containing two tibbles:
 #'   - `modules`: Module assignments and membership values containing the following columns:
 #'     - `variable`: Variable name
@@ -58,6 +58,7 @@
 #'     - `sample`: Sample name
 #'     - `eigenvalue`: Module eigenvalue (first principal component of module expression)
 #' - `raw_result`: The raw WGCNA blockwiseModules object
+#' - `meta_data`: A list containing metadata from the input experiment
 #' The list has classes `glystats_wgcna_res` and `glystats_res`.
 #'
 #' @seealso [WGCNA::pickSoftThreshold()], [WGCNA::blockwiseModules()]
@@ -107,6 +108,10 @@ gly_wgcna <- function(
     exp,
     add_info
   )
+
+  # Add meta_data from experiment
+  result$meta_data <- glyexp::get_meta_data(exp)
+
   result
 }
 

--- a/man/gly_anova.Rd
+++ b/man/gly_anova.Rd
@@ -31,7 +31,7 @@ Only applicable to \code{gly_anova()}.}
 Must have at least 2 levels. Character vectors will be automatically converted to factors.}
 }
 \value{
-A list containing two elements:
+A list containing three elements:
 \itemize{
 \item \code{tidy_result}: A list containing:
 \itemize{
@@ -61,6 +61,7 @@ A list containing two elements:
 \item \code{main_test}: A list of raw \code{aov} model objects.
 \item \code{post_hoc_test}: A list of raw \code{TukeyHSD} objects.
 }
+\item \code{meta_data}: A list containing metadata from the input experiment.
 }
 }
 \description{

--- a/man/gly_consensus_clustering.Rd
+++ b/man/gly_consensus_clustering.Rd
@@ -65,7 +65,7 @@ Only applicable to \code{gly_consensus_clustering()}.}
 \item{expr_mat}{(Only for \code{\link[=gly_consensus_clustering_]{gly_consensus_clustering_()}}) A numeric matrix with variables as rows and samples as columns.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with consensus clustering results containing the following columns:
 \itemize{
@@ -74,6 +74,7 @@ A list with two elements:
 \item \code{cluster}: Cluster assignment for the corresponding k
 }
 \item \code{raw_result}: The raw ConsensusClusterPlus object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_cc_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_cor.Rd
+++ b/man/gly_cor.Rd
@@ -33,7 +33,7 @@ If NULL, no adjustment is performed.}
 \item{expr_mat}{(Only for \code{\link[=gly_cor_]{gly_cor_()}}) A numeric matrix with variables as rows and samples as columns.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with correlation results containing the following columns:
 \itemize{
@@ -44,6 +44,7 @@ A list with two elements:
 \item \code{p_adj}: Adjusted p-value (if p_adj_method is not NULL)
 }
 \item \code{raw_result}: The raw rcorr object from Hmisc::rcorr()
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_cor_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_cox.Rd
+++ b/man/gly_cox.Rd
@@ -42,7 +42,7 @@ Only applicable to \code{gly_cox()}.}
 \item{event}{A numeric vector specifying the event indicator for each sample (1 for event, 0 for censoring).}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with Cox model results containing the following columns:
 \itemize{
@@ -55,6 +55,7 @@ A list with two elements:
 \item \code{p_adj}: Adjusted p-value (if p_adj_method is not NULL)
 }
 \item \code{raw_result}: A list of raw \code{coxph} model objects.
+\item \code{meta_data}: A list containing metadata from the input experiment
 }
 }
 \description{

--- a/man/gly_enrich_dgn.Rd
+++ b/man/gly_enrich_dgn.Rd
@@ -49,7 +49,7 @@ and then passed to \code{universe} of \code{\link[DOSE:enrichDGN]{DOSE::enrichDG
 \item{proteins}{(Only for \code{\link[=gly_enrich_dgn_]{gly_enrich_dgn_()}}) A character vector of UniProt accession IDs.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with enrichment results containing the following columns:
 \itemize{
@@ -64,6 +64,7 @@ A list with two elements:
 \item \code{count}: Number of genes in the term
 }
 \item \code{raw_result}: The raw DOSE enrichResult object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_dgn_ora_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_enrich_do.Rd
+++ b/man/gly_enrich_do.Rd
@@ -60,7 +60,7 @@ and then passed to \code{universe} of \code{\link[DOSE:enrichDO]{DOSE::enrichDO(
 \item{proteins}{(Only for \code{\link[=gly_enrich_do_]{gly_enrich_do_()}}) A character vector of UniProt accession IDs.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with enrichment results containing the following columns:
 \itemize{
@@ -75,6 +75,7 @@ A list with two elements:
 \item \code{count}: Number of genes in the term
 }
 \item \code{raw_result}: The raw DOSE enrichResult object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_do_ora_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_enrich_go.Rd
+++ b/man/gly_enrich_go.Rd
@@ -54,7 +54,7 @@ In this case all detected proteins in this experiment will be extracted and pass
 \item{keytype}{Passed to \code{keyType} of \code{\link[clusterProfiler:enrichGO]{clusterProfiler::enrichGO()}}.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with enrichment results containing the following columns:
 \itemize{
@@ -69,6 +69,7 @@ A list with two elements:
 \item \code{count}: Number of genes in the term
 }
 \item \code{raw_result}: The raw clusterProfiler enrichResult object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_go_ora_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_enrich_kegg.Rd
+++ b/man/gly_enrich_kegg.Rd
@@ -52,7 +52,7 @@ In this case all detected proteins in this experiment will be extracted and pass
 Defaults to "uniprot".}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with enrichment results containing the following columns:
 \itemize{
@@ -67,6 +67,7 @@ A list with two elements:
 \item \code{count}: Number of genes in the term
 }
 \item \code{raw_result}: The raw clusterProfiler enrichResult object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_kegg_ora_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_enrich_ncg.Rd
+++ b/man/gly_enrich_ncg.Rd
@@ -49,7 +49,7 @@ and then passed to \code{universe} of \code{\link[DOSE:enrichNCG]{DOSE::enrichNC
 \item{proteins}{(Only for \code{\link[=gly_enrich_ncg_]{gly_enrich_ncg_()}}) A character vector of UniProt accession IDs.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with enrichment results containing the following columns:
 \itemize{
@@ -64,6 +64,7 @@ A list with two elements:
 \item \code{count}: Number of genes in the term
 }
 \item \code{raw_result}: The raw DOSE enrichResult object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_ncg_ora_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_enrich_reactome.Rd
+++ b/man/gly_enrich_reactome.Rd
@@ -53,7 +53,7 @@ In this case all detected proteins in this experiment will be extracted and pass
 \item{proteins}{(Only for \code{\link[=gly_enrich_reactome_]{gly_enrich_reactome_()}}) A character vector of UniProt accession IDs.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with enrichment results containing the following columns:
 \itemize{
@@ -68,6 +68,7 @@ A list with two elements:
 \item \code{count}: Number of genes in the term
 }
 \item \code{raw_result}: The raw ReactomePA enrichPathway result object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_reactome_ora_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_enrich_wikipathways.Rd
+++ b/man/gly_enrich_wikipathways.Rd
@@ -54,7 +54,7 @@ and then passed to \code{universe} of \code{\link[clusterProfiler:enrichWP]{clus
 \item{proteins}{(Only for \code{\link[=gly_enrich_wikipathways_]{gly_enrich_wikipathways_()}}) A character vector of UniProt accession IDs.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with enrichment results containing the following columns:
 \itemize{
@@ -69,6 +69,7 @@ A list with two elements:
 \item \code{count}: Number of genes in the term
 }
 \item \code{raw_result}: The raw clusterProfiler enrichResult object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_wikipathways_ora_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_fold_change.Rd
+++ b/man/gly_fold_change.Rd
@@ -27,11 +27,16 @@ If more than two groups, pairwise comparisons will be performed,
 with levels coming first as reference groups.}
 }
 \value{
-A tibble with fold change results containing the following columns:
+A list with three elements:
+\itemize{
+\item \code{tidy_result}: A tibble with fold change results containing the following columns:
 \itemize{
 \item \code{variable}: Variable name
 \item \code{log2fc}: Log2 fold change (log2(group2_mean / group1_mean))
 If more than two groups, two additional columns \code{ref_group} and \code{test_group} will be added.
+}
+\item \code{raw_result}: The raw result (same as tidy_result for this function)
+\item \code{meta_data}: A list containing metadata from the input experiment
 }
 }
 \description{

--- a/man/gly_hclust.Rd
+++ b/man/gly_hclust.Rd
@@ -70,6 +70,7 @@ A list containing:
 }
 }
 \item \code{raw_result}: The raw hclust object from \code{stats::hclust()}
+\item \code{meta_data}: A list containing metadata from the input experiment
 }
 }
 \description{

--- a/man/gly_kmeans.Rd
+++ b/man/gly_kmeans.Rd
@@ -36,7 +36,7 @@ Only applicable to \code{gly_kmeans()}.}
 \item{expr_mat}{(Only for \code{\link[=gly_kmeans_]{gly_kmeans_()}}) A numeric matrix with variables as rows and samples as columns.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with cluster assignments containing the following columns:
 \itemize{
@@ -44,6 +44,7 @@ A list with two elements:
 \item \code{cluster}: Cluster assignment
 }
 \item \code{raw_result}: The raw kmeans object from \code{stats::kmeans()}.
+\item \code{meta_data}: A list containing metadata from the input experiment
 }
 }
 \description{

--- a/man/gly_kruskal.Rd
+++ b/man/gly_kruskal.Rd
@@ -37,7 +37,7 @@ Only applicable to \code{gly_kruskal()}.}
 Must have at least 2 levels. Character vectors will be automatically converted to factors.}
 }
 \value{
-A list containing two elements:
+A list containing three elements:
 \itemize{
 \item \code{tidy_result}: A list containing:
 \itemize{
@@ -65,6 +65,7 @@ A list containing two elements:
 \item \code{main_test}: A list of raw \code{kruskal.test} objects.
 \item \code{post_hoc_test}: A list of raw \code{dunnTest} objects.
 }
+\item \code{meta_data}: A list containing metadata from the input experiment.
 }
 }
 \description{

--- a/man/gly_limma.Rd
+++ b/man/gly_limma.Rd
@@ -77,7 +77,7 @@ Must have length equal to \code{ncol(expr_mat)}. If names or row names are provi
 \code{colnames(expr_mat)}, they will be aligned automatically. Default is NULL.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with limma results containing the following columns:
 \itemize{
@@ -92,6 +92,7 @@ A list with two elements:
 \item \code{test_group}: Test group
 }
 \item \code{raw_result}: The raw limma fit object(s).
+\item \code{meta_data}: The meta data from the experiment object (only for \code{gly_limma()}).
 }
 }
 \description{

--- a/man/gly_oplsda.Rd
+++ b/man/gly_oplsda.Rd
@@ -78,6 +78,7 @@ A list containing:
 }
 }
 \item \code{raw_result}: The raw ropls opls object from \code{ropls::opls()}
+\item \code{meta_data}: A list containing metadata from the input experiment
 }
 }
 \description{

--- a/man/gly_pca.Rd
+++ b/man/gly_pca.Rd
@@ -50,6 +50,7 @@ A list containing:
 }
 }
 \item \code{raw_result}: The raw prcomp object from \code{stats::prcomp()}
+\item \code{meta_data}: A list containing metadata from the experiment (only for \code{\link[=gly_pca]{gly_pca()}})
 }
 }
 \description{

--- a/man/gly_plsda.Rd
+++ b/man/gly_plsda.Rd
@@ -73,6 +73,7 @@ A list containing:
 }
 }
 \item \code{raw_result}: The raw ropls opls object from \code{ropls::opls()}
+\item \code{meta_data}: A list containing metadata from the input experiment
 }
 }
 \description{

--- a/man/gly_roc.Rd
+++ b/man/gly_roc.Rd
@@ -30,7 +30,7 @@ Only applicable to \code{gly_roc()}.}
 Must have exactly 2 levels. Character vectors will be automatically converted to factors.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A list containing two tibbles:
 \itemize{
@@ -50,6 +50,7 @@ A list with two elements:
 }
 }
 \item \code{raw_result}: A list of \code{pROC} objects
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_roc_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_tsne.Rd
+++ b/man/gly_tsne.Rd
@@ -25,7 +25,7 @@ Only applicable to \code{gly_tsne()}.}
 \item{expr_mat}{(Only for \code{\link[=gly_tsne_]{gly_tsne_()}}) A numeric matrix with variables as rows and samples as columns.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with t-SNE coordinates containing the following columns:
 \itemize{
@@ -34,6 +34,7 @@ A list with two elements:
 \item \code{tsne2}: Second t-SNE dimension
 }
 \item \code{raw_result}: The raw Rtsne object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_tsne_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_ttest.Rd
+++ b/man/gly_ttest.Rd
@@ -41,7 +41,7 @@ Only applicable to \code{gly_ttest()}.}
 Must have exactly 2 levels. Character vectors will be automatically converted to factors.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with t-test results containing the following columns:
 \itemize{
@@ -60,6 +60,7 @@ A list with two elements:
 \item \code{log2fc}: Log2 fold change (log2(group2_mean / group1_mean))
 }
 \item \code{raw_result}: A list of \code{t.test} model objects
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_ttest_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_umap.Rd
+++ b/man/gly_umap.Rd
@@ -25,7 +25,7 @@ Only applicable to \code{gly_umap()}.}
 \item{expr_mat}{(Only for \code{\link[=gly_umap_]{gly_umap_()}}) A numeric matrix with variables as rows and samples as columns.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with UMAP coordinates containing the following columns:
 \itemize{
@@ -35,6 +35,7 @@ A list with two elements:
 \item \code{umap3}, \code{umap4}, etc.: Additional UMAP dimensions (if n_components > 2)
 }
 \item \code{raw_result}: The raw UMAP result matrix
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_umap_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_wgcna.Rd
+++ b/man/gly_wgcna.Rd
@@ -60,7 +60,7 @@ to the modules tibble. Only applicable to \code{gly_wgcna()}.}
 \item{expr_mat}{(Only for \code{\link[=gly_wgcna_]{gly_wgcna_()}}) A numeric matrix with variables as rows and samples as columns.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A list containing two tibbles:
 \itemize{
@@ -78,6 +78,7 @@ A list with two elements:
 }
 }
 \item \code{raw_result}: The raw WGCNA blockwiseModules object
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_wgcna_res} and \code{glystats_res}.
 }
 }

--- a/man/gly_wilcox.Rd
+++ b/man/gly_wilcox.Rd
@@ -41,7 +41,7 @@ Only applicable to \code{gly_wilcox()}.}
 Must have exactly 2 levels. Character vectors will be automatically converted to factors.}
 }
 \value{
-A list with two elements:
+A list with three elements:
 \itemize{
 \item \code{tidy_result}: A tibble with Wilcoxon test results containing the following columns:
 \itemize{
@@ -55,6 +55,7 @@ A list with two elements:
 Additional columns from experiment metadata may be included if add_info = TRUE.
 }
 \item \code{raw_result}: A list of \code{wilcox.test} model objects
+\item \code{meta_data}: A list containing metadata from the input experiment
 The list has classes \code{glystats_wilcox_res} and \code{glystats_res}.
 }
 }

--- a/tests/testthat/test-add-info.R
+++ b/tests/testthat/test-add-info.R
@@ -15,12 +15,12 @@ test_that("add_info parameter works correctly for functions returning tibbles wi
   ))
 
   expect_equal(
-    colnames(result_no_info),
+    colnames(result_no_info$tidy_result),
     c("variable", "log2fc")
   )
 
   expect_equal(
-    colnames(result_with_info),
+    colnames(result_with_info$tidy_result),
     c(
       "variable",
       "protein",

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -7,10 +7,10 @@ test_that("gly_anova works with anova method", {
   # Run DEA with ANOVA
   result <- suppressMessages(gly_anova(exp_3group))
 
-  # Test core functionality - should return a list with tidy_result and raw_result
+  # Test core functionality - should return a list with tidy_result, raw_result, and meta_data
   expect_type(result, "list")
   expect_s3_class(result, c("glystats_anova_res", "glystats_res"))
-  expect_named(result, c("tidy_result", "raw_result"))
+  expect_named(result, c("tidy_result", "raw_result", "meta_data"))
 
   # Test tidy_result structure
   expect_type(result$tidy_result, "list")
@@ -185,10 +185,10 @@ test_that("gly_kruskal works with kruskal method", {
   # Run DEA with Kruskal-Wallis test
   result <- suppressMessages(gly_kruskal(exp_3group))
 
-  # Test core functionality - should return a list with tidy_result and raw_result
+  # Test core functionality - should return a list with tidy_result, raw_result, and meta_data
   expect_type(result, "list")
   expect_s3_class(result, c("glystats_kruskal_res", "glystats_res"))
-  expect_named(result, c("tidy_result", "raw_result"))
+  expect_named(result, c("tidy_result", "raw_result", "meta_data"))
 
   # Test tidy_result structure
   expect_type(result$tidy_result, "list")

--- a/tests/testthat/test-fold-change.R
+++ b/tests/testthat/test-fold-change.R
@@ -9,22 +9,25 @@ test_that("gly_fold_change works with basic 2-group comparison", {
 
   # Test core functionality
   expect_s3_class(result, "glystats_fc_res")
-  expect_equal(nrow(result), 10)
-  expect_equal(ncol(result), 2)
-  expect_setequal(colnames(result), c("variable", "log2fc"))
-  expect_type(result$variable, "character")
-  expect_type(result$log2fc, "double")
+  expect_equal(nrow(result$tidy_result), 10)
+  expect_equal(ncol(result$tidy_result), 2)
+  expect_setequal(colnames(result$tidy_result), c("variable", "log2fc"))
+  expect_type(result$tidy_result$variable, "character")
+  expect_type(result$tidy_result$log2fc, "double")
 
   # Check that all variables are included
-  expect_setequal(result$variable, glyexp::get_var_info(exp_2group)$variable)
+  expect_setequal(
+    result$tidy_result$variable,
+    glyexp::get_var_info(exp_2group)$variable
+  )
 
   # Test with add_info = TRUE (default)
   result_with_info <- suppressMessages(gly_fold_change(exp_2group))
   expect_s3_class(result_with_info, "glystats_fc_res")
-  expect_equal(nrow(result_with_info), 10)
-  expect_true(ncol(result_with_info) > 2) # Should have more columns with var_info
-  expect_true("variable" %in% colnames(result_with_info))
-  expect_true("log2fc" %in% colnames(result_with_info))
+  expect_equal(nrow(result_with_info$tidy_result), 10)
+  expect_true(ncol(result_with_info$tidy_result) > 2) # Should have more columns with var_info
+  expect_true("variable" %in% colnames(result_with_info$tidy_result))
+  expect_true("log2fc" %in% colnames(result_with_info$tidy_result))
 })
 
 test_that("gly_fold_change works with multi-group comparison", {
@@ -35,12 +38,16 @@ test_that("gly_fold_change works with multi-group comparison", {
     glyexp::slice_sample_var(n = 10)
 
   result <- suppressMessages(gly_fold_change(exp_3group, add_info = FALSE))
-  expect_equal(nrow(result), 30)
+  expect_equal(nrow(result$tidy_result), 30)
   expect_setequal(
-    colnames(result),
+    colnames(result$tidy_result),
     c("variable", "log2fc", "ref_group", "test_group")
   )
-  comparisons <- stringr::str_c(result$ref_group, "_vs_", result$test_group)
+  comparisons <- stringr::str_c(
+    result$tidy_result$ref_group,
+    "_vs_",
+    result$tidy_result$test_group
+  )
   expect_setequal(comparisons, c("H_vs_M", "H_vs_C", "M_vs_C"))
 })
 
@@ -66,9 +73,9 @@ test_that("gly_fold_change works with custom group column", {
   ))
 
   expect_s3_class(result, "glystats_fc_res")
-  expect_equal(nrow(result), 5)
-  expect_equal(ncol(result), 2)
-  expect_setequal(colnames(result), c("variable", "log2fc"))
+  expect_equal(nrow(result$tidy_result), 5)
+  expect_equal(ncol(result$tidy_result), 2)
+  expect_setequal(colnames(result$tidy_result), c("variable", "log2fc"))
 })
 
 test_that("gly_fold_change handles factor groups correctly", {
@@ -81,12 +88,12 @@ test_that("gly_fold_change handles factor groups correctly", {
   result <- suppressMessages(gly_fold_change(exp_2group))
 
   expect_s3_class(result, "glystats_fc_res")
-  expect_equal(nrow(result), 5)
-  expect_type(result$log2fc, "double")
+  expect_equal(nrow(result$tidy_result), 5)
+  expect_type(result$tidy_result$log2fc, "double")
 
   # Check that fold change is calculated correctly (C vs H, H is reference)
   # All values should be finite (no NA/Inf)
-  expect_true(all(is.finite(result$log2fc)))
+  expect_true(all(is.finite(result$tidy_result$log2fc)))
 })
 
 test_that("gly_fold_change error handling", {
@@ -115,8 +122,8 @@ test_that("gly_fold_change handles edge cases", {
   result <- suppressMessages(gly_fold_change(exp_minimal, add_info = FALSE))
 
   expect_s3_class(result, "glystats_fc_res")
-  expect_equal(nrow(result), 1)
-  expect_equal(ncol(result), 2)
+  expect_equal(nrow(result$tidy_result), 1)
+  expect_equal(ncol(result$tidy_result), 2)
 
   # Test with many variables to ensure performance
   exp_large <- test_gp_exp |>
@@ -138,7 +145,7 @@ test_that("gly_fold_change_ works correctly", {
     result <- gly_fold_change_(expr_mat, groups)
   })
 
-  # Verify results
+  # Verify results - gly_fold_change_ returns a tibble directly
   expect_s3_class(result, "glystats_fc_res")
   expect_true(tibble::is_tibble(result))
   expect_setequal(colnames(result), c("variable", "log2fc"))
@@ -165,7 +172,7 @@ test_that("gly_fold_change_ accepts character groups", {
     result_factor <- gly_fold_change_(expr_mat, groups_factor)
   })
 
-  # Results should be identical
+  # Results should be identical (gly_fold_change_ returns tibble directly)
   expect_equal(result_char, result_factor)
   expect_s3_class(result_char, "glystats_fc_res")
   expect_true(tibble::is_tibble(result_char))

--- a/tests/testthat/test-limma.R
+++ b/tests/testthat/test-limma.R
@@ -543,3 +543,30 @@ test_that("gly_limma_ validates subjects length", {
     "subjects must have"
   )
 })
+
+test_that("gly_limma returns meta_data from experiment", {
+  # Use test_gp_exp and filter to 2 groups for limma
+  exp_2group <- test_gp_exp |>
+    glyexp::filter_obs(group %in% c("C", "H")) |>
+    glyexp::slice_sample_var(n = 10)
+
+  result <- suppressMessages(gly_limma(exp_2group))
+
+  # Check that meta_data exists and contains expected values
+  expect_true("meta_data" %in% names(result))
+  expect_equal(result$meta_data$exp_type, "glycoproteomics")
+  expect_equal(result$meta_data$glycan_type, "N")
+})
+
+test_that("gly_limma_ does not return meta_data", {
+  # Use test_gp_exp and extract expression matrix
+  exp_2group <- test_gp_exp |>
+    glyexp::filter_obs(group %in% c("C", "H"))
+  expr_mat <- glyexp::get_expr_mat(exp_2group)
+  groups <- factor(rep(c("C", "H"), each = 3))
+
+  result <- suppressMessages(gly_limma_(expr_mat, groups))
+
+  # Check that meta_data does NOT exist
+  expect_false("meta_data" %in% names(result))
+})

--- a/tests/testthat/test-oplsda.R
+++ b/tests/testthat/test-oplsda.R
@@ -14,7 +14,10 @@ test_that("gly_oplsda works with valid Topliss ratio", {
 
   expect_s3_class(oplsda_res, c("glystats_oplsda_res", "glystats_res"))
   expect_type(oplsda_res, "list")
-  expect_setequal(names(oplsda_res), c("tidy_result", "raw_result"))
+  expect_setequal(
+    names(oplsda_res),
+    c("tidy_result", "raw_result", "meta_data")
+  )
 
   # Check tidy_result structure
   expect_type(oplsda_res$tidy_result, "list")

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -4,7 +4,7 @@ test_that("gly_pca works", {
   pca_res <- gly_pca(test_gp_exp)
   expect_s3_class(pca_res, c("glystats_pca_res", "glystats_res"))
   expect_type(pca_res, "list")
-  expect_setequal(names(pca_res), c("tidy_result", "raw_result"))
+  expect_setequal(names(pca_res), c("tidy_result", "raw_result", "meta_data"))
 
   # Check tidy_result structure
   expect_type(pca_res$tidy_result, "list")
@@ -100,4 +100,47 @@ test_that("gly_pca_ handles all constant columns", {
     expect_warning(gly_pca_(expr_mat, scale = TRUE)),
     "No columns with non-zero variance remain"
   )
+})
+
+test_that("gly_pca returns meta_data from experiment", {
+  # Create a simple experiment with metadata
+  expr_mat <- matrix(runif(20), nrow = 5, ncol = 4)
+  colnames(expr_mat) <- c("S1", "S2", "S3", "S4")
+  rownames(expr_mat) <- c("V1", "V2", "V3", "V4", "V5")
+
+  sample_info <- tibble::tibble(
+    sample = c("S1", "S2", "S3", "S4"),
+    group = factor(c("A", "A", "B", "B"))
+  )
+
+  var_info <- tibble::tibble(
+    variable = c("V1", "V2", "V3", "V4", "V5"),
+    var_type = c("A", "B", "C", "D", "E")
+  )
+
+  exp <- glyexp::experiment(
+    expr_mat,
+    sample_info,
+    var_info,
+    exp_type = "others",
+    custom_field = "test_value"
+  )
+
+  result <- gly_pca(exp)
+
+  # Check that meta_data exists and contains expected values
+  expect_true("meta_data" %in% names(result))
+  expect_equal(result$meta_data$exp_type, "others")
+  expect_equal(result$meta_data$custom_field, "test_value")
+})
+
+test_that("gly_pca_ does not return meta_data", {
+  expr_mat <- matrix(runif(20), nrow = 5, ncol = 4)
+  colnames(expr_mat) <- c("S1", "S2", "S3", "S4")
+  rownames(expr_mat) <- c("V1", "V2", "V3", "V4", "V5")
+
+  result <- gly_pca_(expr_mat)
+
+  # Check that meta_data does NOT exist
+  expect_false("meta_data" %in% names(result))
 })

--- a/tests/testthat/test-plsda.R
+++ b/tests/testthat/test-plsda.R
@@ -14,7 +14,7 @@ test_that("gly_plsda works with valid dataset", {
 
   expect_s3_class(plsda_res, c("glystats_plsda_res", "glystats_res"))
   expect_type(plsda_res, "list")
-  expect_setequal(names(plsda_res), c("tidy_result", "raw_result"))
+  expect_setequal(names(plsda_res), c("tidy_result", "raw_result", "meta_data"))
 
   # Check tidy_result structure
   expect_type(plsda_res$tidy_result, "list")

--- a/tests/testthat/test-roc.R
+++ b/tests/testthat/test-roc.R
@@ -13,7 +13,7 @@ test_that("gly_roc works with 2-group binary classification", {
   # Test structure
   expect_s3_class(result, c("glystats_roc_res", "glystats_res"))
   expect_type(result, "list")
-  expect_setequal(names(result), c("tidy_result", "raw_result"))
+  expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
 
   # Test tidy_result structure
   expect_type(result$tidy_result, "list")
@@ -73,7 +73,7 @@ test_that("gly_roc works with automatic pos_class detection", {
   # Test basic structure
   expect_s3_class(result, c("glystats_roc_res", "glystats_res"))
   expect_type(result, "list")
-  expect_setequal(names(result), c("tidy_result", "raw_result"))
+  expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
   expect_s3_class(result$tidy_result$coords, "tbl_df")
 })
 
@@ -123,7 +123,7 @@ test_that("gly_roc works with different group column names", {
 
   expect_s3_class(result, c("glystats_roc_res", "glystats_res"))
   expect_type(result, "list")
-  expect_setequal(names(result), c("tidy_result", "raw_result"))
+  expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
 })
 
 test_that("gly_roc assigns NA for failed variables", {
@@ -171,7 +171,7 @@ test_that("gly_roc_ works correctly", {
     result <- gly_roc_(expr_mat, groups, pos_class = "B")
   })
 
-  # Verify results
+  # Verify results - gly_roc_ returns only tidy_result and raw_result (no meta_data)
   expect_s3_class(result, "glystats_roc_res")
   expect_type(result, "list")
   expect_setequal(names(result), c("tidy_result", "raw_result"))

--- a/tests/testthat/test-tsne.R
+++ b/tests/testthat/test-tsne.R
@@ -9,7 +9,7 @@ test_that("gly_tsne works with default parameters", {
   # Check basic structure
   expect_s3_class(result, c("glystats_tsne_res", "glystats_res"))
   expect_type(result, "list")
-  expect_setequal(names(result), c("tidy_result", "raw_result"))
+  expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
 
   # Check tidy_result structure
   expect_s3_class(result$tidy_result, "tbl_df")

--- a/tests/testthat/test-ttest.R
+++ b/tests/testthat/test-ttest.R
@@ -10,7 +10,7 @@ test_that("gly_ttest works with t-test method", {
   # Test core functionality
   expect_s3_class(result, c("glystats_ttest_res", "glystats_res"))
   expect_type(result, "list")
-  expect_setequal(names(result), c("tidy_result", "raw_result"))
+  expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
   expect_equal(nrow(result$tidy_result), 10)
   expect_true("p_adj" %in% colnames(result$tidy_result)) # p_adj should exist
   expect_true("log2fc" %in% colnames(result$tidy_result)) # log2fc should exist
@@ -55,7 +55,7 @@ test_that("gly_wilcox works with wilcoxon method", {
   # Test core functionality
   expect_s3_class(result, c("glystats_wilcox_res", "glystats_res"))
   expect_type(result, "list")
-  expect_setequal(names(result), c("tidy_result", "raw_result"))
+  expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
   expect_equal(nrow(result$tidy_result), 10)
   expect_true("log2fc" %in% colnames(result$tidy_result)) # Wilcoxon should now have log2fc
   expect_type(result$tidy_result$log2fc, "double") # log2fc should be numeric

--- a/tests/testthat/test-umap.R
+++ b/tests/testthat/test-umap.R
@@ -9,7 +9,7 @@ test_that("gly_umap works with default parameters", {
   # Check basic structure
   expect_s3_class(result, c("glystats_umap_res", "glystats_res"))
   expect_type(result, "list")
-  expect_setequal(names(result), c("tidy_result", "raw_result"))
+  expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
 
   # Check tidy_result structure
   expect_s3_class(result$tidy_result, "tbl_df")


### PR DESCRIPTION
## Summary

- Add `meta_data` field to all top-level `gly_*()` function results
- `meta_data` contains experiment metadata from `glyexp::get_meta_data(exp)`
- Underlying `gly_*_()` functions (matrix-based API) remain unchanged
- Updated roxygen documentation for all modified functions
- Added tests for `gly_ttest`, `gly_limma`, and `gly_pca`

## New Result Structure

Top-level API now returns:
```r
list(
  tidy_result = <tibble>,
  raw_result = <raw objects>,
  meta_data = <experiment metadata>
)
```

## Test Plan

- [x] All 800 tests pass
- [x] `devtools::check()` passes with 0 errors, 0 warnings, 0 notes
- [x] Code formatted with `air format .`

## Modified Functions

`gly_ttest()`, `gly_wilcox()`, `gly_anova()`, `gly_kruskal()`, `gly_pca()`, `gly_tsne()`, `gly_umap()`, `gly_plsda()`, `gly_oplsda()`, `gly_limma()`, `gly_cor()`, `gly_cox()`, `gly_roc()`, `gly_fold_change()`, `gly_enrich_*()`, `gly_hclust()`, `gly_kmeans()`, `gly_consensus_clustering()`, `gly_wgcna()`