### PR TITLE
feat: add effect size calculations for statistical tests

### DIFF
--- a/R/anova.R
+++ b/R/anova.R
@@ -47,6 +47,7 @@
 #'       - `meansq`: Mean squares
 #'       - `statistic`: F-statistic
 #'       - `p_val`: Raw p-value from ANOVA
+#'       - `effect_size`: Eta-squared
 #'       - `p_adj`: Adjusted p-value (if p_adj_method is not NULL)
 #'       - `post_hoc`: Significant group pairs from post-hoc test, in the format of "ref_vs_test".
 #'     - `post_hoc_test`: A tibble with pairwise comparison results containing the following columns:
@@ -146,7 +147,10 @@ gly_anova_ <- function(
   main_test <- .tibblify_main_test_results(
     raw_main_test,
     stats::aov,
-    p_adj_method
+    p_adj_method,
+    effect_size_method = "eta_squared",
+    expr_mat = expr_mat,
+    groups = groups
   )
   post_hoc_vec <- .format_posthoc_results(
     raw_post_hoc_test,
@@ -458,6 +462,7 @@ gly_ancova_ <- function(
 #'       - `p_val`: Raw p-value from Kruskal-Wallis test
 #'       - `parameter`: Degrees of freedom
 #'       - `method`: Statistical method used
+#'       - `effect_size`: Epsilon-squared
 #'       - `p_adj`: Adjusted p-value (if p_adj_method is not NULL)
 #'       - `post_hoc`: Significant group pairs from post-hoc test, in the format of "ref_vs_test".
 #'     - `post_hoc_test`: A tibble with pairwise comparison results containing the following columns:
@@ -563,7 +568,10 @@ gly_kruskal_ <- function(
   main_test <- .tibblify_main_test_results(
     raw_main_test,
     stats::kruskal.test,
-    p_adj_method
+    p_adj_method,
+    effect_size_method = "epsilon_squared",
+    expr_mat = expr_mat,
+    groups = groups
   )
   post_hoc_vec <- .format_posthoc_results(
     raw_post_hoc_test,
@@ -772,7 +780,14 @@ gly_kruskal_ <- function(
 }
 
 # Helper function to convert main test raw results to tibble
-.tibblify_main_test_results <- function(main_test_raw, .f, p_adj_method) {
+.tibblify_main_test_results <- function(
+  main_test_raw,
+  .f,
+  p_adj_method,
+  effect_size_method = NULL,
+  expr_mat = NULL,
+  groups = NULL
+) {
   var_names <- names(main_test_raw)
   result_tbl <- tibble::tibble(
     variable = var_names,
@@ -810,7 +825,113 @@ gly_kruskal_ <- function(
     )
   }
 
+  if (!is.null(effect_size_method)) {
+    result_tbl <- .add_effect_size_to_main_test(
+      result_tbl,
+      effect_size_method,
+      expr_mat,
+      groups
+    )
+  }
+
   result_tbl
+}
+
+#' Add effect sizes to multi-group main test results
+#'
+#' @param result_tbl A tibble containing the tidy main test results.
+#' @param effect_size_method A character string naming the effect size to compute.
+#' @param expr_mat A numeric matrix with variables as rows and samples as columns.
+#' @param groups A factor specifying group membership for each sample.
+#'
+#' @return A tibble with an `effect_size` column added.
+#' @noRd
+.add_effect_size_to_main_test <- function(
+  result_tbl,
+  effect_size_method,
+  expr_mat,
+  groups
+) {
+  effect_size_values <- purrr::map_dbl(result_tbl$variable, function(var_name) {
+    if (identical(effect_size_method, "eta_squared")) {
+      .calculate_eta_squared(expr_mat, groups, var_name)
+    } else if (identical(effect_size_method, "epsilon_squared")) {
+      .calculate_epsilon_squared(expr_mat, groups, var_name)
+    } else {
+      NA_real_
+    }
+  })
+
+  result_tbl$effect_size <- effect_size_values
+  result_tbl
+}
+
+#' Calculate eta-squared for one-way ANOVA
+#'
+#' @param expr_mat A numeric matrix with variables as rows and samples as columns.
+#' @param groups A factor specifying group membership for each sample.
+#' @param var_name A character string specifying the variable to evaluate.
+#'
+#' @return A numeric scalar containing eta-squared.
+#' @noRd
+.calculate_eta_squared <- function(expr_mat, groups, var_name) {
+  log_values <- log2(expr_mat[var_name, ] + 1)
+  valid_idx <- !is.na(log_values) & !is.na(groups)
+  log_values <- log_values[valid_idx]
+  groups <- droplevels(groups[valid_idx])
+
+  if (length(log_values) == 0 || nlevels(groups) < 2) {
+    return(NA_real_)
+  }
+
+  grand_mean <- mean(log_values)
+  group_means <- purrr::map_dbl(levels(groups), function(group) {
+    mean(log_values[groups == group])
+  })
+  group_sizes <- purrr::map_int(levels(groups), function(group) {
+    sum(groups == group)
+  })
+  ss_between <- sum(group_sizes * (group_means - grand_mean)^2)
+  ss_total <- sum((log_values - grand_mean)^2)
+
+  if (!is.finite(ss_total) || ss_total == 0) {
+    return(NA_real_)
+  }
+
+  ss_between / ss_total
+}
+
+#' Calculate epsilon-squared for the Kruskal-Wallis test
+#'
+#' @param expr_mat A numeric matrix with variables as rows and samples as columns.
+#' @param groups A factor specifying group membership for each sample.
+#' @param var_name A character string specifying the variable to evaluate.
+#'
+#' @return A numeric scalar containing epsilon-squared.
+#' @noRd
+.calculate_epsilon_squared <- function(expr_mat, groups, var_name) {
+  log_values <- log2(expr_mat[var_name, ] + 1)
+  valid_idx <- !is.na(log_values) & !is.na(groups)
+  log_values <- log_values[valid_idx]
+  groups <- droplevels(groups[valid_idx])
+
+  if (
+    length(log_values) == 0 ||
+      nlevels(groups) < 2 ||
+      length(log_values) <= nlevels(groups)
+  ) {
+    return(NA_real_)
+  }
+
+  h_stat <- suppressWarnings(
+    unname(stats::kruskal.test(log_values, groups)$statistic)
+  )
+
+  if (!is.finite(h_stat)) {
+    return(NA_real_)
+  }
+
+  (h_stat - nlevels(groups) + 1) / (length(log_values) - nlevels(groups))
 }
 
 # Helper function to convert post-hoc raw results to tibble

--- a/R/anova.R
+++ b/R/anova.R
@@ -132,7 +132,8 @@ gly_anova_ <- function(
   }
 
   # Prepare data
-  data <- .prepare_multi_group_data(expr_mat, groups)
+  log_expr_mat <- .log_transform_expr_mat(expr_mat)
+  data <- .prepare_multi_group_data(log_expr_mat, groups, is_logged = TRUE)
 
   # Generate raw results
   raw_main_test <- .generate_raw_main_results(data, stats::aov, ...)
@@ -149,7 +150,7 @@ gly_anova_ <- function(
     stats::aov,
     p_adj_method,
     effect_size_method = "eta_squared",
-    expr_mat = expr_mat,
+    expr_mat = log_expr_mat,
     groups = groups
   )
   post_hoc_vec <- .format_posthoc_results(
@@ -353,7 +354,13 @@ gly_ancova_ <- function(
   }
 
   # Prepare data
-  data <- .prepare_multi_group_data(expr_mat, groups, covariates)
+  log_expr_mat <- .log_transform_expr_mat(expr_mat)
+  data <- .prepare_multi_group_data(
+    log_expr_mat,
+    groups,
+    covariates,
+    is_logged = TRUE
+  )
   ancova_formula <- stats::reformulate(
     termlabels = c("group", colnames(covariates)),
     response = "log_value"
@@ -553,7 +560,8 @@ gly_kruskal_ <- function(
   }
 
   # Prepare data
-  data <- .prepare_multi_group_data(expr_mat, groups)
+  log_expr_mat <- .log_transform_expr_mat(expr_mat)
+  data <- .prepare_multi_group_data(log_expr_mat, groups, is_logged = TRUE)
 
   # Generate raw results
   raw_main_test <- .generate_raw_main_results(data, stats::kruskal.test, ...)
@@ -570,7 +578,7 @@ gly_kruskal_ <- function(
     stats::kruskal.test,
     p_adj_method,
     effect_size_method = "epsilon_squared",
-    expr_mat = expr_mat,
+    expr_mat = log_expr_mat,
     groups = groups
   )
   post_hoc_vec <- .format_posthoc_results(
@@ -752,7 +760,12 @@ gly_kruskal_ <- function(
 }
 
 # Helper function to prepare data for analysis
-.prepare_multi_group_data <- function(expr_mat, groups, covariates = NULL) {
+.prepare_multi_group_data <- function(
+  expr_mat,
+  groups,
+  covariates = NULL,
+  is_logged = FALSE
+) {
   data <- expr_mat %>%
     t() %>%
     as.data.frame() %>%
@@ -770,13 +783,19 @@ gly_kruskal_ <- function(
     keep_cols <- c(keep_cols, colnames(covariates))
   }
 
-  data %>%
+  data <- data %>%
     tidyr::pivot_longer(
       cols = -all_of(keep_cols),
       names_to = "variable",
-      values_to = "value"
-    ) %>%
-    dplyr::mutate(log_value = log2(.data$value + 1))
+      values_to = "log_value"
+    )
+
+  if (!is_logged) {
+    data <- data %>%
+      dplyr::mutate(log_value = log2(.data$log_value + 1))
+  }
+
+  data
 }
 
 # Helper function to convert main test raw results to tibble
@@ -826,6 +845,12 @@ gly_kruskal_ <- function(
   }
 
   if (!is.null(effect_size_method)) {
+    if (is.null(expr_mat) || is.null(groups)) {
+      cli::cli_abort(
+        "{.arg expr_mat} and {.arg groups} must be supplied when {.arg effect_size_method} is used."
+      )
+    }
+
     result_tbl <- .add_effect_size_to_main_test(
       result_tbl,
       effect_size_method,
@@ -852,15 +877,22 @@ gly_kruskal_ <- function(
   expr_mat,
   groups
 ) {
-  effect_size_values <- purrr::map_dbl(result_tbl$variable, function(var_name) {
-    if (identical(effect_size_method, "eta_squared")) {
-      .calculate_eta_squared(expr_mat, groups, var_name)
-    } else if (identical(effect_size_method, "epsilon_squared")) {
-      .calculate_epsilon_squared(expr_mat, groups, var_name)
-    } else {
-      NA_real_
+  checkmate::assert_choice(
+    effect_size_method,
+    c("eta_squared", "epsilon_squared")
+  )
+
+  effect_size_values <- purrr::map2_dbl(
+    result_tbl$variable,
+    result_tbl$statistic,
+    function(var_name, statistic) {
+      if (identical(effect_size_method, "eta_squared")) {
+        .calculate_eta_squared(expr_mat, groups, var_name)
+      } else {
+        .calculate_epsilon_squared(expr_mat, groups, var_name, statistic)
+      }
     }
-  })
+  )
 
   result_tbl$effect_size <- effect_size_values
   result_tbl
@@ -875,7 +907,7 @@ gly_kruskal_ <- function(
 #' @return A numeric scalar containing eta-squared.
 #' @noRd
 .calculate_eta_squared <- function(expr_mat, groups, var_name) {
-  log_values <- log2(expr_mat[var_name, ] + 1)
+  log_values <- expr_mat[var_name, ]
   valid_idx <- !is.na(log_values) & !is.na(groups)
   log_values <- log_values[valid_idx]
   groups <- droplevels(groups[valid_idx])
@@ -909,8 +941,8 @@ gly_kruskal_ <- function(
 #'
 #' @return A numeric scalar containing epsilon-squared.
 #' @noRd
-.calculate_epsilon_squared <- function(expr_mat, groups, var_name) {
-  log_values <- log2(expr_mat[var_name, ] + 1)
+.calculate_epsilon_squared <- function(expr_mat, groups, var_name, h_stat) {
+  log_values <- expr_mat[var_name, ]
   valid_idx <- !is.na(log_values) & !is.na(groups)
   log_values <- log_values[valid_idx]
   groups <- droplevels(groups[valid_idx])
@@ -922,10 +954,6 @@ gly_kruskal_ <- function(
   ) {
     return(NA_real_)
   }
-
-  h_stat <- suppressWarnings(
-    unname(stats::kruskal.test(log_values, groups)$statistic)
-  )
 
   if (!is.finite(h_stat)) {
     return(NA_real_)

--- a/R/ttest.R
+++ b/R/ttest.R
@@ -299,13 +299,16 @@ gly_wilcox_ <- function(
     groups <- .reorder_groups_for_ref(groups, ref_group)
   }
 
-  mod_list <- .gly_dea_2groups_raw(expr_mat, groups, .f, ...)
+  log_expr_mat <- .log_transform_expr_mat(expr_mat)
+
+  mod_list <- .gly_dea_2groups_raw(log_expr_mat, groups, .f, ...)
   tidy_result <- .gly_dea_2groups_tibblify(
     mod_list,
     .f,
     p_adj_method,
     expr_mat,
-    groups
+    groups,
+    log_expr_mat
   )
 
   # Return list with both tidy and raw results
@@ -316,8 +319,8 @@ gly_wilcox_ <- function(
 }
 
 # Generate raw model list for 2-group analysis
-.gly_dea_2groups_raw <- function(expr_mat, groups, .f, ...) {
-  data <- expr_mat %>%
+.gly_dea_2groups_raw <- function(log_expr_mat, groups, .f, ...) {
+  data <- log_expr_mat %>%
     t() %>%
     as.data.frame() %>%
     tibble::rownames_to_column("sample") %>%
@@ -326,9 +329,8 @@ gly_wilcox_ <- function(
     tidyr::pivot_longer(
       cols = -all_of(c("sample", "group")),
       names_to = "variable",
-      values_to = "value"
-    ) %>%
-    dplyr::mutate(log_value = log2(.data$value + 1))
+      values_to = "log_value"
+    )
 
   # Perform statistical tests and store raw results
   dots <- rlang::list2(...)
@@ -366,7 +368,8 @@ gly_wilcox_ <- function(
   .f,
   p_adj_method,
   expr_mat,
-  groups
+  groups,
+  log_expr_mat
 ) {
   # Create a tibble from the model list
   var_names <- names(mod_list)
@@ -402,7 +405,12 @@ gly_wilcox_ <- function(
 
   # Calculate log2 fold change
   result_tbl <- .add_log2fc_to_result(result_tbl, expr_mat, groups)
-  result_tbl <- .add_effect_size_to_2group_result(result_tbl, expr_mat, groups, .f)
+  result_tbl <- .add_effect_size_to_2group_result(
+    result_tbl,
+    log_expr_mat,
+    groups,
+    .f
+  )
 
   result_tbl
 }
@@ -466,7 +474,7 @@ gly_wilcox_ <- function(
 #' @return A numeric scalar containing Cohen's d.
 #' @noRd
 .calculate_cohens_d <- function(expr_mat, groups, var_name) {
-  log_values <- log2(expr_mat[var_name, ] + 1)
+  log_values <- expr_mat[var_name, ]
   group_levels <- levels(groups)
   ref_values <- log_values[groups == group_levels[1]]
   test_values <- log_values[groups == group_levels[2]]
@@ -500,7 +508,7 @@ gly_wilcox_ <- function(
 #' @return A numeric scalar containing the rank-biserial correlation.
 #' @noRd
 .calculate_rank_biserial <- function(expr_mat, groups, var_name) {
-  log_values <- log2(expr_mat[var_name, ] + 1)
+  log_values <- expr_mat[var_name, ]
   group_levels <- levels(groups)
   ref_values <- log_values[groups == group_levels[1]]
   test_values <- log_values[groups == group_levels[2]]
@@ -518,6 +526,16 @@ gly_wilcox_ <- function(
   u_stat <- sum(test_ranks) - test_size * (test_size + 1) / 2
 
   (2 * u_stat / (ref_size * test_size)) - 1
+}
+
+#' Log-transform an expression matrix
+#'
+#' @param expr_mat A numeric matrix with variables as rows and samples as columns.
+#'
+#' @return A numeric matrix with log2(x + 1) values.
+#' @noRd
+.log_transform_expr_mat <- function(expr_mat) {
+  log2(expr_mat + 1)
 }
 
 # Helper function to reorder groups so that ref_group becomes the first level

--- a/R/ttest.R
+++ b/R/ttest.R
@@ -41,6 +41,7 @@
 #'   - `parameter`: Degrees of freedom
 #'   - `conf_low`: Lower bound of 95% confidence interval
 #'   - `conf_high`: Upper bound of 95% confidence interval
+#'   - `effect_size`: Cohen's d
 #'   - `method`: Statistical method used
 #'   - `alternative`: Alternative hypothesis
 #'   - `p_adj`: Adjusted p-value (if p_adj_method is not NULL)
@@ -177,6 +178,7 @@ gly_ttest_ <- function(
 #'   - `variable`: Variable name
 #'   - `statistic`: Wilcoxon test statistic
 #'   - `p_val`: Raw p-value from Wilcoxon test
+#'   - `effect_size`: Rank-biserial correlation
 #'   - `method`: Statistical method used
 #'   - `alternative`: Alternative hypothesis
 #'   - `p_adj`: Adjusted p-value (if p_adj_method is not NULL)
@@ -400,6 +402,7 @@ gly_wilcox_ <- function(
 
   # Calculate log2 fold change
   result_tbl <- .add_log2fc_to_result(result_tbl, expr_mat, groups)
+  result_tbl <- .add_effect_size_to_2group_result(result_tbl, expr_mat, groups, .f)
 
   result_tbl
 }
@@ -428,6 +431,93 @@ gly_wilcox_ <- function(
   result_tbl$log2fc <- log2fc_values
 
   result_tbl
+}
+
+#' Add effect sizes to two-group differential analysis results
+#'
+#' @param result_tbl A tibble containing the tidy test results.
+#' @param expr_mat A numeric matrix with variables as rows and samples as columns.
+#' @param groups A factor specifying group membership for each sample.
+#' @param .f The statistical test function used to generate the results.
+#'
+#' @return A tibble with an `effect_size` column added.
+#' @noRd
+.add_effect_size_to_2group_result <- function(result_tbl, expr_mat, groups, .f) {
+  effect_size_values <- purrr::map_dbl(result_tbl$variable, function(var_name) {
+    if (identical(.f, stats::t.test)) {
+      .calculate_cohens_d(expr_mat, groups, var_name)
+    } else if (identical(.f, stats::wilcox.test)) {
+      .calculate_rank_biserial(expr_mat, groups, var_name)
+    } else {
+      NA_real_
+    }
+  })
+
+  result_tbl$effect_size <- effect_size_values
+  result_tbl
+}
+
+#' Calculate Cohen's d for a two-group comparison
+#'
+#' @param expr_mat A numeric matrix with variables as rows and samples as columns.
+#' @param groups A factor specifying group membership for each sample.
+#' @param var_name A character string specifying the variable to evaluate.
+#'
+#' @return A numeric scalar containing Cohen's d.
+#' @noRd
+.calculate_cohens_d <- function(expr_mat, groups, var_name) {
+  log_values <- log2(expr_mat[var_name, ] + 1)
+  group_levels <- levels(groups)
+  ref_values <- log_values[groups == group_levels[1]]
+  test_values <- log_values[groups == group_levels[2]]
+  ref_values <- ref_values[!is.na(ref_values)]
+  test_values <- test_values[!is.na(test_values)]
+
+  if (length(ref_values) < 2 || length(test_values) < 2) {
+    return(NA_real_)
+  }
+
+  pooled_sd <- sqrt(
+    (
+      ((length(ref_values) - 1) * stats::sd(ref_values)^2) +
+        ((length(test_values) - 1) * stats::sd(test_values)^2)
+    ) / (length(ref_values) + length(test_values) - 2)
+  )
+
+  if (!is.finite(pooled_sd) || pooled_sd == 0) {
+    return(NA_real_)
+  }
+
+  (mean(test_values) - mean(ref_values)) / pooled_sd
+}
+
+#' Calculate rank-biserial correlation for a two-group comparison
+#'
+#' @param expr_mat A numeric matrix with variables as rows and samples as columns.
+#' @param groups A factor specifying group membership for each sample.
+#' @param var_name A character string specifying the variable to evaluate.
+#'
+#' @return A numeric scalar containing the rank-biserial correlation.
+#' @noRd
+.calculate_rank_biserial <- function(expr_mat, groups, var_name) {
+  log_values <- log2(expr_mat[var_name, ] + 1)
+  group_levels <- levels(groups)
+  ref_values <- log_values[groups == group_levels[1]]
+  test_values <- log_values[groups == group_levels[2]]
+  ref_values <- ref_values[!is.na(ref_values)]
+  test_values <- test_values[!is.na(test_values)]
+
+  if (length(ref_values) == 0 || length(test_values) == 0) {
+    return(NA_real_)
+  }
+
+  combined_values <- c(ref_values, test_values)
+  test_ranks <- rank(combined_values)[(length(ref_values) + 1):length(combined_values)]
+  test_size <- length(test_values)
+  ref_size <- length(ref_values)
+  u_stat <- sum(test_ranks) - test_size * (test_size + 1) / 2
+
+  (2 * u_stat / (ref_size * test_size)) - 1
 }
 
 # Helper function to reorder groups so that ref_group becomes the first level

--- a/man/gly_anova.Rd
+++ b/man/gly_anova.Rd
@@ -44,6 +44,7 @@ A list containing three elements:
 \item \code{meansq}: Mean squares
 \item \code{statistic}: F-statistic
 \item \code{p_val}: Raw p-value from ANOVA
+\item \code{effect_size}: Eta-squared
 \item \code{p_adj}: Adjusted p-value (if p_adj_method is not NULL)
 \item \code{post_hoc}: Significant group pairs from post-hoc test, in the format of "ref_vs_test".
 }

--- a/man/gly_kruskal.Rd
+++ b/man/gly_kruskal.Rd
@@ -48,6 +48,7 @@ A list containing three elements:
 \item \code{p_val}: Raw p-value from Kruskal-Wallis test
 \item \code{parameter}: Degrees of freedom
 \item \code{method}: Statistical method used
+\item \code{effect_size}: Epsilon-squared
 \item \code{p_adj}: Adjusted p-value (if p_adj_method is not NULL)
 \item \code{post_hoc}: Significant group pairs from post-hoc test, in the format of "ref_vs_test".
 }

--- a/man/gly_ttest.Rd
+++ b/man/gly_ttest.Rd
@@ -54,6 +54,7 @@ A list with three elements:
 \item \code{parameter}: Degrees of freedom
 \item \code{conf_low}: Lower bound of 95\% confidence interval
 \item \code{conf_high}: Upper bound of 95\% confidence interval
+\item \code{effect_size}: Cohen's d
 \item \code{method}: Statistical method used
 \item \code{alternative}: Alternative hypothesis
 \item \code{p_adj}: Adjusted p-value (if p_adj_method is not NULL)

--- a/man/gly_wilcox.Rd
+++ b/man/gly_wilcox.Rd
@@ -48,6 +48,7 @@ A list with three elements:
 \item \code{variable}: Variable name
 \item \code{statistic}: Wilcoxon test statistic
 \item \code{p_val}: Raw p-value from Wilcoxon test
+\item \code{effect_size}: Rank-biserial correlation
 \item \code{method}: Statistical method used
 \item \code{alternative}: Alternative hypothesis
 \item \code{p_adj}: Adjusted p-value (if p_adj_method is not NULL)

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -421,6 +421,37 @@ test_that("gly_kruskal_ returns epsilon-squared in effect_size", {
   )
 })
 
+test_that(".tibblify_main_test_results validates effect-size inputs", {
+  expr_mat <- matrix(
+    c(1, 2, 3, 5, 6, 7, 9, 10, 11),
+    nrow = 1,
+    dimnames = list("var1", paste0("sample", 1:9))
+  )
+  groups <- factor(rep(c("A", "B", "C"), each = 3))
+  log_values <- log2(expr_mat["var1", ] + 1)
+  main_test_raw <- list(var1 = stats::kruskal.test(log_values ~ groups))
+
+  expect_error(
+    .tibblify_main_test_results(
+      main_test_raw,
+      stats::kruskal.test,
+      p_adj_method = NULL,
+      effect_size_method = "epsilon_squared"
+    ),
+    "must be supplied"
+  )
+
+  expect_error(
+    .add_effect_size_to_main_test(
+      tibble::tibble(variable = "var1", statistic = unname(main_test_raw$var1$statistic)),
+      effect_size_method = "bad_method",
+      expr_mat = expr_mat,
+      groups = groups
+    ),
+    "Must be element of set"
+  )
+})
+
 test_that("post_hoc_test should not contain NA rows when add_info is TRUE", {
   # Run ANOVA with add_info = TRUE (default)
   result <- suppressMessages(gly_anova(test_gp_exp))

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -22,6 +22,8 @@ test_that("gly_anova works with anova method", {
   expect_equal(nrow(main_test), 10)
   expect_true("p_adj" %in% colnames(main_test))
   expect_true("post_hoc" %in% colnames(main_test))
+  expect_true("effect_size" %in% colnames(main_test))
+  expect_type(main_test$effect_size, "double")
 
   # Test post_hoc_test tibble
   post_hoc_test <- result$tidy_result$post_hoc_test
@@ -254,6 +256,8 @@ test_that("gly_kruskal works with kruskal method", {
   expect_true("method" %in% colnames(main_test))
 
   expect_true("post_hoc" %in% colnames(main_test))
+  expect_true("effect_size" %in% colnames(main_test))
+  expect_type(main_test$effect_size, "double")
   expect_false("log2fc" %in% colnames(main_test))
 
   # Test post_hoc_test tibble
@@ -332,6 +336,40 @@ test_that("gly_anova_ works correctly", {
   expect_named(result, c("tidy_result", "raw_result"))
   expect_true(tibble::is_tibble(result$tidy_result$main_test))
   expect_equal(nrow(result$tidy_result$main_test), 10)
+  expect_true("effect_size" %in% colnames(result$tidy_result$main_test))
+})
+
+test_that("gly_anova_ returns eta-squared in effect_size", {
+  expr_mat <- matrix(
+    c(1, 2, 3, 5, 6, 7, 9, 10, 11),
+    nrow = 1,
+    dimnames = list("var1", paste0("sample", 1:9))
+  )
+  groups <- factor(rep(c("A", "B", "C"), each = 3))
+
+  result <- suppressMessages(gly_anova_(
+    expr_mat,
+    groups,
+    p_adj_method = NULL
+  ))
+
+  log_values <- log2(c(1, 2, 3, 5, 6, 7, 9, 10, 11) + 1)
+  grand_mean <- mean(log_values)
+  group_means <- purrr::map_dbl(levels(groups), function(group) {
+    mean(log_values[groups == group])
+  })
+  group_sizes <- purrr::map_int(levels(groups), function(group) {
+    sum(groups == group)
+  })
+  ss_between <- sum(group_sizes * (group_means - grand_mean)^2)
+  ss_total <- sum((log_values - grand_mean)^2)
+  expected <- ss_between / ss_total
+
+  expect_equal(
+    result$tidy_result$main_test$effect_size,
+    expected,
+    tolerance = 1e-10
+  )
 })
 
 test_that("gly_kruskal_ works correctly", {
@@ -353,6 +391,34 @@ test_that("gly_kruskal_ works correctly", {
   expect_named(result, c("tidy_result", "raw_result"))
   expect_true(tibble::is_tibble(result$tidy_result$main_test))
   expect_equal(nrow(result$tidy_result$main_test), 10)
+  expect_true("effect_size" %in% colnames(result$tidy_result$main_test))
+})
+
+test_that("gly_kruskal_ returns epsilon-squared in effect_size", {
+  expr_mat <- matrix(
+    c(1, 2, 3, 5, 6, 7, 9, 10, 11),
+    nrow = 1,
+    dimnames = list("var1", paste0("sample", 1:9))
+  )
+  groups <- factor(rep(c("A", "B", "C"), each = 3))
+
+  result <- suppressMessages(gly_kruskal_(
+    expr_mat,
+    groups,
+    p_adj_method = NULL
+  ))
+
+  log_values <- log2(c(1, 2, 3, 5, 6, 7, 9, 10, 11) + 1)
+  h_stat <- unname(stats::kruskal.test(log_values ~ groups)$statistic)
+  n_obs <- length(log_values)
+  n_groups <- nlevels(groups)
+  expected <- (h_stat - n_groups + 1) / (n_obs - n_groups)
+
+  expect_equal(
+    result$tidy_result$main_test$effect_size,
+    expected,
+    tolerance = 1e-10
+  )
 })
 
 test_that("post_hoc_test should not contain NA rows when add_info is TRUE", {

--- a/tests/testthat/test-ttest.R
+++ b/tests/testthat/test-ttest.R
@@ -14,7 +14,9 @@ test_that("gly_ttest works with t-test method", {
   expect_equal(nrow(result$tidy_result), 10)
   expect_true("p_adj" %in% colnames(result$tidy_result)) # p_adj should exist
   expect_true("log2fc" %in% colnames(result$tidy_result)) # log2fc should exist
+  expect_true("effect_size" %in% colnames(result$tidy_result))
   expect_type(result$tidy_result$log2fc, "double") # log2fc should be numeric
+  expect_type(result$tidy_result$effect_size, "double")
 
   # Test raw_result
   expect_type(result$raw_result, "list")
@@ -58,7 +60,9 @@ test_that("gly_wilcox works with wilcoxon method", {
   expect_setequal(names(result), c("tidy_result", "raw_result", "meta_data"))
   expect_equal(nrow(result$tidy_result), 10)
   expect_true("log2fc" %in% colnames(result$tidy_result)) # Wilcoxon should now have log2fc
+  expect_true("effect_size" %in% colnames(result$tidy_result))
   expect_type(result$tidy_result$log2fc, "double") # log2fc should be numeric
+  expect_type(result$tidy_result$effect_size, "double")
 
   # Test raw_result
   expect_type(result$raw_result, "list")
@@ -85,7 +89,34 @@ test_that("gly_ttest_ works correctly", {
   expect_setequal(names(result), c("tidy_result", "raw_result"))
   expect_true(nrow(result$tidy_result) > 0)
   expect_true("log2fc" %in% colnames(result$tidy_result))
+  expect_true("effect_size" %in% colnames(result$tidy_result))
   expect_equal(nrow(result$tidy_result), 10)
+})
+
+test_that("gly_ttest_ returns Cohen's d in effect_size", {
+  expr_mat <- matrix(
+    c(1, 2, 3, 8, 9, 10),
+    nrow = 1,
+    dimnames = list("var1", paste0("sample", 1:6))
+  )
+  groups <- factor(c("A", "A", "A", "B", "B", "B"))
+
+  result <- suppressMessages(gly_ttest_(
+    expr_mat,
+    groups,
+    p_adj_method = NULL
+  ))
+
+  log_values <- log2(c(1, 2, 3, 8, 9, 10) + 1)
+  group_a <- log_values[1:3]
+  group_b <- log_values[4:6]
+  pooled_sd <- sqrt((
+    ((length(group_a) - 1) * stats::sd(group_a)^2) +
+      ((length(group_b) - 1) * stats::sd(group_b)^2)
+  ) / (length(group_a) + length(group_b) - 2))
+  expected <- (mean(group_b) - mean(group_a)) / pooled_sd
+
+  expect_equal(result$tidy_result$effect_size, expected, tolerance = 1e-10)
 })
 
 test_that("gly_ttest_ direction matches log2fc and ref_group", {
@@ -280,7 +311,34 @@ test_that("gly_wilcox_ works correctly", {
   expect_setequal(names(result), c("tidy_result", "raw_result"))
   expect_true(nrow(result$tidy_result) > 0)
   expect_true("log2fc" %in% colnames(result$tidy_result))
+  expect_true("effect_size" %in% colnames(result$tidy_result))
   expect_equal(nrow(result$tidy_result), 10)
+})
+
+test_that("gly_wilcox_ returns rank-biserial correlation in effect_size", {
+  expr_mat <- matrix(
+    c(1, 2, 3, 8, 9, 10),
+    nrow = 1,
+    dimnames = list("var1", paste0("sample", 1:6))
+  )
+  groups <- factor(c("A", "A", "A", "B", "B", "B"))
+
+  result <- suppressMessages(suppressWarnings(gly_wilcox_(
+    expr_mat,
+    groups,
+    p_adj_method = NULL,
+    exact = FALSE
+  )))
+
+  log_values <- log2(c(1, 2, 3, 8, 9, 10) + 1)
+  ranks <- rank(log_values)
+  n_ref <- 3
+  n_test <- 3
+  w_stat <- sum(ranks[4:6])
+  u_stat <- w_stat - n_test * (n_test + 1) / 2
+  expected <- (2 * u_stat / (n_ref * n_test)) - 1
+
+  expect_equal(result$tidy_result$effect_size, expected, tolerance = 1e-10)
 })
 
 test_that("gly_ttest and gly_wilcox basic functionality works", {


### PR DESCRIPTION
## Summary

Add effect size calculations to all statistical test functions in glystats:

- `gly_anova` / `gly_anova_`: Eta-squared
- `gly_kruskal` / `gly_kruskal_`: Epsilon-squared
- `gly_ttest` / `gly_ttest_`: Cohen's d
- `gly_wilcox` / `gly_wilcox_`: Rank-biserial correlation

Effect sizes are computed on log2-transformed expression values and added as an `effect_size` column in the tidy result tibbles.

## Changes

- Added `.add_effect_size_to_main_test()` and `.add_effect_size_to_2group_result()` helper functions
- Added `.calculate_eta_squared()`, `.calculate_epsilon_squared()`, `.calculate_cohens_d()`, `.calculate_rank_biserial()` computation functions
- Updated documentation strings and man pages
- Added unit tests verifying exact expected values

## Test plan

- [x] `devtools::test(filter = \"anova\")` passes
- [x] `devtools::test(filter = \"ttest\")` passes
- [x] `devtools::test()` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)