### PR TITLE
feat: add S3 class validation and improve get_tidy_result error handling

### DIFF
--- a/R/get-res.R
+++ b/R/get-res.R
@@ -5,7 +5,8 @@
 #'
 #' @param res A glystats result object.
 #' @param which Used to specify which element to get, when the result is a list.
-#'   If NULL, the whole result (tibble or list) will be returned.
+#'   For glystats results with only one tidy result (e.g. [gly_ttest()]), this argument is not needed.
+#'   For others (e.g. [gly_anova()]), this argument is required to specify which tidy result to get.
 #'
 #' @returns A tibble.
 #'

--- a/R/get-res.R
+++ b/R/get-res.R
@@ -31,20 +31,22 @@
 #' @export
 get_tidy_result <- function(res, which = NULL) {
   checkmate::assert_class(res, "glystats_res")
-  if (is.null(which) && !tibble::is_tibble(res$tidy_result)) {
-    cli::cli_abort(c(
-      "{.arg which} must be provided for {.cls {class(res)[[1]]}} result.",
-      "i" = "Available tibbles: {.val {names(res$tidy_result)}}"
-    ))
+
+  if (is.null(which)) {
+    if (!tibble::is_tibble(res$tidy_result)) {
+      cli::cli_abort(c(
+        "{.arg which} must be provided for {.cls {class(res)[[1]]}} result.",
+        "i" = "Available tibbles: {.val {names(res$tidy_result)}}"
+      ))
+    } else {
+      return(res$tidy_result)
+    }
   }
+
   if (!which %in% names(res$tidy_result)) {
     cli::cli_abort(c(
       "{.arg which} must be one of {.val {names(res$tidy_result)}}"
     ))
-  }
-
-  if (is.null(which)) {
-    return(res$tidy_result)
   }
   return(res$tidy_result[[which]])
 }

--- a/R/get-res.R
+++ b/R/get-res.R
@@ -31,13 +31,20 @@
 #' @export
 get_tidy_result <- function(res, which = NULL) {
   checkmate::check_class(res, "glystats_res")
-  if (is.null(which)) {
-    return(res$tidy_result)
+  if (is.null(which) && !tibble::is_tibble(res$tidy_result)) {
+    cli::cli_abort(c(
+      "{.arg which} must be provided for {.cls {class(res)[[1]]}} result.",
+      "i" = "Available tibbles: {.val {names(res$tidy_result)}}"
+    ))
   }
   if (!which %in% names(res$tidy_result)) {
     cli::cli_abort(c(
       "{.arg which} must be one of {.val {names(res$tidy_result)}}"
     ))
+  }
+
+  if (is.null(which)) {
+    return(res$tidy_result)
   }
   return(res$tidy_result[[which]])
 }

--- a/R/get-res.R
+++ b/R/get-res.R
@@ -30,7 +30,7 @@
 #'
 #' @export
 get_tidy_result <- function(res, which = NULL) {
-  checkmate::check_class(res, "glystats_res")
+  checkmate::assert_class(res, "glystats_res")
   if (is.null(which) && !tibble::is_tibble(res$tidy_result)) {
     cli::cli_abort(c(
       "{.arg which} must be provided for {.cls {class(res)[[1]]}} result.",
@@ -52,7 +52,7 @@ get_tidy_result <- function(res, which = NULL) {
 #' @rdname get_tidy_result
 #' @export
 get_raw_result <- function(res, which = NULL) {
-  checkmate::check_class(res, "glystats_res")
+  checkmate::assert_class(res, "glystats_res")
   if (is.null(which)) {
     return(res$raw_result)
   }

--- a/R/get-res.R
+++ b/R/get-res.R
@@ -30,6 +30,7 @@
 #'
 #' @export
 get_tidy_result <- function(res, which = NULL) {
+  checkmate::check_class(res, "glystats_res")
   if (is.null(which)) {
     return(res$tidy_result)
   }
@@ -44,6 +45,7 @@ get_tidy_result <- function(res, which = NULL) {
 #' @rdname get_tidy_result
 #' @export
 get_raw_result <- function(res, which = NULL) {
+  checkmate::check_class(res, "glystats_res")
   if (is.null(which)) {
     return(res$raw_result)
   }

--- a/man/get_tidy_result.Rd
+++ b/man/get_tidy_result.Rd
@@ -13,7 +13,8 @@ get_raw_result(res, which = NULL)
 \item{res}{A glystats result object.}
 
 \item{which}{Used to specify which element to get, when the result is a list.
-If NULL, the whole result (tibble or list) will be returned.}
+For glystats results with only one tidy result (e.g. \code{\link[=gly_ttest]{gly_ttest()}}), this argument is not needed.
+For others (e.g. \code{\link[=gly_anova]{gly_anova()}}), this argument is required to specify which tidy result to get.}
 }
 \value{
 A tibble.

--- a/tests/testthat/test-get-res.R
+++ b/tests/testthat/test-get-res.R
@@ -17,3 +17,9 @@ test_that("get_tidy_result raises error if tidy_result is a list but no `which` 
   result <- suppressMessages(gly_anova(test_gp_exp))
   expect_error(get_tidy_result(result), "must be provided for")
 })
+
+test_that("get_tidy_result works when tidy_result is already a tibble", {
+  result <- suppressMessages(gly_fold_change(test_gp_exp))
+  expect_no_error(tidy_result <- get_tidy_result(result))
+  expect_s3_class(tidy_result, "tbl_df")
+})

--- a/tests/testthat/test-get-res.R
+++ b/tests/testthat/test-get-res.R
@@ -1,7 +1,6 @@
 test_that("get_tidy_result works", {
   result <- suppressMessages(gly_anova(test_gp_exp))
   expect_s3_class(get_tidy_result(result, "main_test"), "tbl_df")
-  expect_type(get_tidy_result(result), "list")
 })
 
 test_that("get_raw_result works", {
@@ -12,4 +11,9 @@ test_that("get_raw_result works", {
 test_that("get_tidy_result raises error if which is not in tidy_result", {
   result <- suppressMessages(gly_anova(test_gp_exp))
   expect_error(get_tidy_result(result, "nonexistent"), "must be one of")
+})
+
+test_that("get_tidy_result raises error if tidy_result is a list but no `which` is provided", {
+  result <- suppressMessages(gly_anova(test_gp_exp))
+  expect_error(get_tidy_result(result), "must be provided for")
 })


### PR DESCRIPTION
## Summary
- Add `checkmate::check_class()` to `get_tidy_result()` and `get_raw_result()` for input validation.
- Make `get_tidy_result()` type-stable: it now always returns a tibble (or errors), instead of sometimes returning a list when `which` is omitted.
- Require `which` when `tidy_result` is a list, with a clear error message showing available tibbles.
- Update tests to cover the new validation behavior.

## Test plan
- [ ] Run `devtools::test(filter = \"get-res\")`
- [ ] Run `devtools::test()` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)