### PR TITLE
feat: support SummarizedExperiment inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ Description: Provides a unified toolbox for bioinformatics analyses of glycomics
     (Cox proportional hazards), correlation analysis, and ROC/AUC evaluation.
     All user-facing functions follow the gly_*() naming
     convention to facilitate auto-completion in RStudio. Analysis functions
-    accept 'glyexp' experiment objects as their unified data interface.
+    accept 'glyexp' experiment and 'SummarizedExperiment' objects as their
+    unified data interface.
 License: MIT + file LICENSE
 Suggests:
     testthat (>= 3.0.0),
@@ -39,7 +40,7 @@ RoxygenNote: 7.3.3
 URL: https://glycoverse.github.io/glystats/
 Imports:
     tibble,
-    glyexp (>= 0.12.3),
+    glyexp (>= 0.15.0),
     rlang,
     tidyr,
     dplyr,
@@ -53,7 +54,10 @@ Imports:
     purrr,
     stringr,
     survival,
-    glyrepr (>= 0.9.0)
+    glyrepr (>= 0.9.0),
+    SummarizedExperiment,
+    S4Vectors,
+    methods
 Depends: 
     R (>= 4.1)
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glystats (development version)
 
+## New features
+
+* All `gly_*()` analysis functions and `filter_sig_vars()` now accept `SummarizedExperiment` objects in addition to `glyexp::experiment()` objects.
+
 ## Breaking changes
 
 * All `gly_*_()` matrix and vector interfaces are removed. Pass a `glyexp::experiment()` to the corresponding `gly_*()` function instead. (#12)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* All `gly_*()` analysis functions and `filter_sig_vars()` now accept `SummarizedExperiment` objects in addition to `glyexp::experiment()` objects.
+* All `gly_*()` analysis functions and `filter_sig_vars()` now accept `SummarizedExperiment` objects in addition to `glyexp::experiment()` objects. (#14)
 
 ## Breaking changes
 

--- a/R/anova.R
+++ b/R/anova.R
@@ -5,7 +5,8 @@
 #' For significant results, Tukey's HSD post-hoc test is automatically performed.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.
@@ -63,7 +64,7 @@ gly_anova <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_choice(
     p_adj_method,
@@ -73,8 +74,8 @@ gly_anova <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups
   group_info <- .extract_and_validate_groups(
@@ -94,7 +95,7 @@ gly_anova <- function(
     add_info
   )
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
   result
 }
 
@@ -183,7 +184,8 @@ gly_anova <- function(
 #' For significant results, emmeans post-hoc comparisons (Tukey adjustment) are automatically performed.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param covariate_cols A character vector specifying column names in sample information
@@ -243,7 +245,7 @@ gly_ancova <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_choice(
     p_adj_method,
@@ -258,8 +260,8 @@ gly_ancova <- function(
   checkmate::assert_character(covariate_cols, min.len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups
   group_info <- .extract_and_validate_groups(
@@ -408,7 +410,8 @@ gly_ancova <- function(
 #' For significant results, Dunn's post-hoc test is automatically performed.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.
@@ -467,7 +470,7 @@ gly_kruskal <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_choice(
     p_adj_method,
@@ -480,8 +483,8 @@ gly_kruskal <- function(
   rlang::check_installed("FSA")
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups
   group_info <- .extract_and_validate_groups(
@@ -501,7 +504,7 @@ gly_kruskal <- function(
     add_info
   )
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
   result
 }
 

--- a/R/cor.R
+++ b/R/cor.R
@@ -4,7 +4,8 @@
 #' The function calculates correlation coefficients and p-values for all pairs,
 #' with optional multiple testing correction.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param on A character string specifying what to correlate. Either "variable" (default) to correlate
 #'   variables/features, or "sample" to correlate samples/observations.
 #' @param method A character string indicating which correlation coefficient is to be computed.
@@ -51,7 +52,7 @@ gly_cor <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_choice(on, c("variable", "sample"))
   checkmate::assert_choice(method, c("pearson", "spearman"))
   checkmate::assert_choice(
@@ -61,13 +62,13 @@ gly_cor <- function(
   )
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
+  expr_mat <- .get_expr_mat(exp)
 
   # Run the internal computation
   result <- .analyze_cor(expr_mat, on, method, p_adj_method, ...)
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/cox.R
+++ b/R/cox.R
@@ -3,7 +3,8 @@
 #' Fit a Cox proportional hazards model for each variable in the expression data,
 #' and extract p-values and hazard ratios from it.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param time_col A character string specifying the column name in sample information
 #'   that contains survival time. Default is "time".
 #' @param event_col A character string specifying the column name in sample information
@@ -47,13 +48,13 @@ gly_cox <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(time_col)
   checkmate::assert_string(event_col)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract time and event vectors
   time <- sample_info[[time_col]]
@@ -68,7 +69,7 @@ gly_cox <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/filter-sig-vars.R
+++ b/R/filter-sig-vars.R
@@ -5,7 +5,8 @@
 #' It supports results from all glystats DEA functions including
 #' [gly_anova()], [gly_ancova()], [gly_kruskal()], [gly_ttest()], [gly_wilcox()], and [gly_limma()].
 #'
-#' @param exp An [glyexp::experiment()]. Please use the same experiment used to generate the DEA result.
+#' @param exp A [glyexp::experiment()] or `SummarizedExperiment` object. Use the
+#'   same object used to generate the DEA result.
 #' @param res A glystats result object from a glystats DEA function.
 #' @param p_adj_cutoff The threshold for p-adjusted values. Default is 0.05.
 #' @param p_val_cutoff The threshold for p-values. We don't recommend using this. Default is NULL.
@@ -15,7 +16,7 @@
 #'   Default is `2` for glycoproteomics data and `NULL` for others.
 #' @param ... Additional arguments passed to methods. See the method-specific documentation for details.
 #'
-#' @returns An new [glyexp::experiment()] object.
+#' @returns A filtered object of the same class as `exp`.
 #'
 #' @examples
 #' library(glyexp)
@@ -226,7 +227,7 @@ filter_sig_vars.glystats_limma_res <- function(
   }
 
   sig_vars <- sig_df |> dplyr::pull("variable") |> unique()
-  glyexp::filter_var(exp, .data$variable %in% sig_vars)
+  .filter_variables(exp, sig_vars)
 }
 
 .filter_sig_vars_ttest <- function(
@@ -241,7 +242,7 @@ filter_sig_vars.glystats_limma_res <- function(
     .add_filters(p_adj_cutoff, p_val_cutoff, fc_cutoff) |>
     dplyr::pull("variable") |>
     unique()
-  glyexp::filter_var(exp, .data$variable %in% sig_vars)
+  .filter_variables(exp, sig_vars)
 }
 
 .filter_sig_vars_limma <- function(
@@ -258,7 +259,7 @@ filter_sig_vars.glystats_limma_res <- function(
   }
   df <- .add_filters(df, p_adj_cutoff, p_val_cutoff, fc_cutoff)
   sig_vars <- df |> dplyr::pull("variable") |> unique()
-  glyexp::filter_var(exp, .data$variable %in% sig_vars)
+  .filter_variables(exp, sig_vars)
 }
 
 .add_filters <- function(df, p_adj_cutoff, p_val_cutoff, fc_cutoff) {
@@ -291,7 +292,7 @@ filter_sig_vars.glystats_limma_res <- function(
   comparison
 ) {
   # Type checking
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_number(p_adj_cutoff, lower = 0, upper = 1, null.ok = TRUE)
   checkmate::assert_number(p_val_cutoff, lower = 0, upper = 1, null.ok = TRUE)
   checkmate::assert_number(fc_cutoff, lower = 1, null.ok = TRUE)
@@ -422,7 +423,7 @@ filter_sig_vars.glystats_limma_res <- function(
   if (!is.null(user_provided)) {
     return(user_provided)
   }
-  if (glyexp::get_exp_type(exp) == "glycoproteomics") {
+  if (identical(.get_exp_type(exp), "glycoproteomics")) {
     return(2)
   }
   NULL

--- a/R/fold-change.R
+++ b/R/fold-change.R
@@ -5,7 +5,7 @@
 #' When you run this function, you will see message about "Ref Group" and "Test Group".
 #' "Ref Group" is the reference group, and "Test Group" is the test/treatment/case group.
 #'
-#' @param exp A `glyexp::experiment()` object.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object.
 #' @param group_col The column name of the group information in the sample information.
 #' @param add_info A logical value. If TRUE (default), variable information from the experiment
 #'  will be added to the result tibble. If FALSE, only the fold change results are returned.
@@ -19,12 +19,12 @@
 #'  - `meta_data`: A list containing metadata from the input experiment
 #' @export
 gly_fold_change <- function(exp, group_col = "group", add_info = TRUE) {
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract and validate groups using helper function
-  sample_info <- glyexp::get_sample_info(exp)
+  sample_info <- .get_sample_info(exp)
   group_info <- .extract_and_validate_groups(
     sample_info = sample_info,
     group_col = group_col,
@@ -34,7 +34,7 @@ gly_fold_change <- function(exp, group_col = "group", add_info = TRUE) {
   )
   groups <- group_info$groups
 
-  expr_mat <- glyexp::get_expr_mat(exp)
+  expr_mat <- .get_expr_mat(exp)
 
   # Run the internal computation
   tidy_result <- .analyze_fold_change(expr_mat, groups)
@@ -46,7 +46,7 @@ gly_fold_change <- function(exp, group_col = "group", add_info = TRUE) {
   result <- list(
     tidy_result = tidy_result,
     raw_result = tidy_result,
-    meta_data = glyexp::get_meta_data(exp)
+    meta_data = .get_meta_data(exp)
   )
   class(result) <- c("glystats_fc_res", "glystats_res", class(result))
 

--- a/R/hclust.R
+++ b/R/hclust.R
@@ -5,7 +5,8 @@
 #' tidy results including cluster assignments, dendrogram data for plotting,
 #' and merge heights.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param on A character string specifying what to cluster. Either "variable" (default) to cluster
 #'   variables/features, or "sample" to cluster samples/observations.
 #' @param k_values A numeric vector specifying the number of clusters to cut the tree into.
@@ -66,7 +67,7 @@ gly_hclust <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_choice(on, c("variable", "sample"))
   if (!is.null(k_values)) {
     checkmate::assert_integerish(k_values, lower = 2, min.len = 1)
@@ -75,7 +76,7 @@ gly_hclust <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
+  expr_mat <- .get_expr_mat(exp)
 
   # Run the internal computation
   result <- .analyze_hclust(expr_mat, on, k_values, scale, ...)
@@ -86,7 +87,7 @@ gly_hclust <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -4,7 +4,8 @@
 #' The function uses `stats::kmeans()` to perform clustering and provides
 #' tidy results with cluster assignments.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param on A character string specifying what to cluster. Either "variable" (default) to cluster
 #'   variables/features, or "sample" to cluster samples/observations.
 #' @param centers Either the number of clusters (integer) or a set of initial cluster centers.
@@ -47,7 +48,7 @@ gly_kmeans <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_choice(on, c("variable", "sample"))
   checkmate::assert(
     checkmate::check_integerish(centers, lower = 1, len = 1),
@@ -57,7 +58,7 @@ gly_kmeans <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
+  expr_mat <- .get_expr_mat(exp)
 
   # Run the internal computation
   result <- .analyze_kmeans(expr_mat, on, centers, scale, ...)
@@ -68,7 +69,7 @@ gly_kmeans <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/limma.R
+++ b/R/limma.R
@@ -3,7 +3,8 @@
 #' Perform differential expression analysis using linear models with empirical Bayes
 #' moderation from the limma package. Supports both two-group and multi-group comparisons.
 #'
-#' @param exp A `glyexp_experiment` object containing expression data and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   expression data and sample information.
 #' @param group_col A character string specifying the column name in sample information
 #'   that contains group labels. Default is "group".
 #' @param covariate_cols A character vector specifying column names in sample information
@@ -77,7 +78,7 @@ gly_limma <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   if (length(covariate_cols) == 0) {
     covariate_cols <- NULL
@@ -99,8 +100,8 @@ gly_limma <- function(
   rlang::check_installed("limma")
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups (minimum 2 groups, no maximum limit)
   group_info <- .extract_and_validate_groups(
@@ -147,7 +148,7 @@ gly_limma <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/oplsda.R
+++ b/R/oplsda.R
@@ -3,7 +3,8 @@
 #' Perform orthogonal partial least squares discriminant analysis on the expression data.
 #' The function uses `ropls::opls()` to perform OPLS-DA and returns tidy results.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name in sample information
 #'   that contains group labels. Default is "group".
 #' @param pred_i An integer indicating the number of predictive components to include. Default is 1.
@@ -57,7 +58,7 @@ gly_oplsda <- function(
   rlang::check_installed("ropls")
 
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_int(pred_i, lower = 1)
   if (!is.na(ortho_i)) {
@@ -67,8 +68,8 @@ gly_oplsda <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups (OPLS-DA only supports binary classification)
   group_info <- .extract_and_validate_groups(
@@ -89,7 +90,7 @@ gly_oplsda <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/pca.R
+++ b/R/pca.R
@@ -4,7 +4,8 @@
 #' The function uses `prcomp()` to perform PCA and `broom::tidy()` to tidy the results.
 #' If `scale = TRUE`, constant variables (zero variance) will be removed before PCA.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param center A logical indicating whether to center the data. Default is TRUE.
 #' @param scale A logical indicating whether to scale the data. Default is TRUE.
 #' @param add_info A logical value. If TRUE (default), sample and variable information from the experiment
@@ -38,11 +39,11 @@
 #' @seealso [stats::prcomp()]
 #' @export
 gly_pca <- function(exp, center = TRUE, scale = TRUE, add_info = TRUE, ...) {
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
+  expr_mat <- .get_expr_mat(exp)
 
   # Run the internal computation
   result <- .analyze_pca(expr_mat, center, scale, ...)
@@ -53,7 +54,7 @@ gly_pca <- function(exp, center = TRUE, scale = TRUE, add_info = TRUE, ...) {
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -3,7 +3,8 @@
 #' Perform partial least squares discriminant analysis on the expression data.
 #' The function uses `ropls::opls()` to perform PLS-DA and returns tidy results.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name in sample information
 #'   that contains group labels. Default is "group".
 #' @param ncomp An integer indicating the number of components to include. Default is 2.
@@ -53,15 +54,15 @@ gly_plsda <- function(
   rlang::check_installed("ropls")
 
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_int(ncomp, lower = 1)
   checkmate::assert_logical(scale, len = 1)
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups
   group_info <- .extract_and_validate_groups(
@@ -82,7 +83,7 @@ gly_plsda <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/roc.R
+++ b/R/roc.R
@@ -5,7 +5,8 @@
 #' Area Under the Curve (AUC) values for each variable to assess their discriminatory
 #' power between two groups.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'   in the sample information. Default is `"group"`. The grouping variable must have
 #'   exactly 2 levels for binary classification.
@@ -56,14 +57,14 @@ gly_roc <- function(
   rlang::check_installed("pROC")
 
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_string(pos_class, null.ok = TRUE)
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups using helper function
   group_info <- .extract_and_validate_groups(
@@ -85,7 +86,7 @@ gly_roc <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/tsne.R
+++ b/R/tsne.R
@@ -3,7 +3,8 @@
 #' Perform t-SNE dimensionality reduction on the expression data.
 #' The function uses `Rtsne::Rtsne()` to perform t-SNE analysis.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param dims Number of output dimensions. Default is 2.
 #' @param perplexity Perplexity parameter for t-SNE. Default is 30.
 #' @param add_info A logical value. If TRUE (default), sample information from the experiment
@@ -24,10 +25,10 @@
 #' @seealso [Rtsne::Rtsne()]
 #' @export
 gly_tsne <- function(exp, dims = 2, perplexity = 30, add_info = TRUE, ...) {
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_logical(add_info, len = 1)
 
-  expr_mat <- glyexp::get_expr_mat(exp)
+  expr_mat <- .get_expr_mat(exp)
   result <- .analyze_tsne(expr_mat, dims, perplexity, ...)
 
   result$tidy_result <- .process_results_add_info(
@@ -37,7 +38,7 @@ gly_tsne <- function(exp, dims = 2, perplexity = 30, add_info = TRUE, ...) {
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/ttest.R
+++ b/R/ttest.R
@@ -4,7 +4,8 @@
 #' The function supports Student's t-test for comparing two groups.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.
@@ -50,7 +51,7 @@ gly_ttest <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_choice(
     p_adj_method,
@@ -60,8 +61,8 @@ gly_ttest <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups
   group_info <- .extract_and_validate_groups(
@@ -85,7 +86,7 @@ gly_ttest <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }
@@ -138,7 +139,8 @@ gly_ttest <- function(
 #' The function supports non-parametric comparison of two groups.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.
@@ -186,7 +188,7 @@ gly_wilcox <- function(
   ...
 ) {
   # Validate inputs
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_string(group_col)
   checkmate::assert_choice(
     p_adj_method,
@@ -196,8 +198,8 @@ gly_wilcox <- function(
   checkmate::assert_logical(add_info, len = 1)
 
   # Extract data from experiment object
-  expr_mat <- glyexp::get_expr_mat(exp)
-  sample_info <- glyexp::get_sample_info(exp)
+  expr_mat <- .get_expr_mat(exp)
+  sample_info <- .get_sample_info(exp)
 
   # Extract and validate groups
   group_info <- .extract_and_validate_groups(
@@ -221,7 +223,7 @@ gly_wilcox <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/umap.R
+++ b/R/umap.R
@@ -3,7 +3,8 @@
 #' Perform UMAP dimensionality reduction on the expression data.
 #' The function uses `uwot::umap()` to perform UMAP analysis.
 #'
-#' @param exp A `glyexp::experiment()` object containing expression matrix and sample information.
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
+#'   an expression matrix and sample information.
 #' @param n_neighbors Number of neighbors to consider for each point. Default is 15.
 #' @param n_components Number of output dimensions. Default is 2.
 #' @param add_info A logical value. If TRUE (default), sample information from the experiment
@@ -32,10 +33,10 @@ gly_umap <- function(
   ...
 ) {
   rlang::check_installed("uwot")
-  checkmate::assert_class(exp, "glyexp_experiment")
+  .assert_data_container(exp)
   checkmate::assert_flag(add_info)
 
-  expr_mat <- glyexp::get_expr_mat(exp)
+  expr_mat <- .get_expr_mat(exp)
   result <- .analyze_umap(expr_mat, n_neighbors, n_components, ...)
 
   result$tidy_result <- .process_results_add_info(
@@ -45,7 +46,7 @@ gly_umap <- function(
   )
 
   # Add meta_data from experiment
-  result$meta_data <- glyexp::get_meta_data(exp)
+  result$meta_data <- .get_meta_data(exp)
 
   result
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,103 @@
+# Data-container helpers -------------------------------------------------------
+
+#' Check a glystats data-container input
+#'
+#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object.
+#'
+#' @returns `NULL` invisibly, or an error if `exp` is unsupported.
+#' @noRd
+.assert_data_container <- function(exp) {
+  if (glyexp::is_experiment(exp) || methods::is(exp, "SummarizedExperiment")) {
+    return(invisible(NULL))
+  }
+
+  cli::cli_abort(
+    "{.arg exp} must be a {.cls glyexp_experiment} or {.cls SummarizedExperiment} object."
+  )
+}
+
+#' Extract the expression matrix from a glystats data container
+#'
+#' @inheritParams .assert_data_container
+#'
+#' @returns A numeric matrix with variables in rows and samples in columns.
+#' @noRd
+.get_expr_mat <- function(exp) {
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(as.matrix(SummarizedExperiment::assay(exp, 1)))
+  }
+  glyexp::get_expr_mat(exp)
+}
+
+#' Extract sample information from a glystats data container
+#'
+#' @inheritParams .assert_data_container
+#'
+#' @returns A tibble with a `sample` identifier column.
+#' @noRd
+.get_sample_info <- function(exp) {
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(tibble::as_tibble(
+      SummarizedExperiment::colData(exp),
+      rownames = "sample"
+    ))
+  }
+  glyexp::get_sample_info(exp)
+}
+
+#' Extract variable information from a glystats data container
+#'
+#' @inheritParams .assert_data_container
+#'
+#' @returns A tibble with a `variable` identifier column.
+#' @noRd
+.get_var_info <- function(exp) {
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(tibble::as_tibble(
+      SummarizedExperiment::rowData(exp),
+      rownames = "variable"
+    ))
+  }
+  glyexp::get_var_info(exp)
+}
+
+#' Extract metadata from a glystats data container
+#'
+#' @inheritParams .assert_data_container
+#'
+#' @returns A metadata list.
+#' @noRd
+.get_meta_data <- function(exp) {
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(S4Vectors::metadata(exp))
+  }
+  glyexp::get_meta_data(exp)
+}
+
+#' Extract the experiment type from a glystats data container
+#'
+#' @inheritParams .assert_data_container
+#'
+#' @returns A character scalar or `NULL`.
+#' @noRd
+.get_exp_type <- function(exp) {
+  .get_meta_data(exp)$exp_type
+}
+
+#' Filter variables in a glystats data container
+#'
+#' @inheritParams .assert_data_container
+#' @param variables A character vector of variable identifiers to retain.
+#'
+#' @returns The filtered container, preserving its input class.
+#' @noRd
+.filter_variables <- function(exp, variables) {
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(exp[rownames(exp) %in% variables, ])
+  }
+  glyexp::filter_var(exp, .data$variable %in% .env$variables)
+}
+
 # Group extraction, validation, and conversion helper functions ---------------
 
 # Check if group column exists in sample information
@@ -142,7 +242,7 @@
     return(tbl)
   }
 
-  var_info <- glyexp::get_var_info(exp)
+  var_info <- .get_var_info(exp)
   # Remove the variable column from var_info to avoid duplication
   var_info_subset <- var_info[,
     !colnames(var_info) %in% "variable",
@@ -164,7 +264,7 @@
     return(tbl)
   }
 
-  sample_info <- glyexp::get_sample_info(exp)
+  sample_info <- .get_sample_info(exp)
   # Remove the sample column from sample_info to avoid duplication
   sample_info_subset <- sample_info[,
     !colnames(sample_info) %in% "sample",

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,10 +37,7 @@
 #' @noRd
 .get_sample_info <- function(exp) {
   if (methods::is(exp, "SummarizedExperiment")) {
-    return(tibble::as_tibble(
-      SummarizedExperiment::colData(exp),
-      rownames = "sample"
-    ))
+    return(.as_info_tibble(SummarizedExperiment::colData(exp), "sample"))
   }
   glyexp::get_sample_info(exp)
 }
@@ -53,12 +50,25 @@
 #' @noRd
 .get_var_info <- function(exp) {
   if (methods::is(exp, "SummarizedExperiment")) {
-    return(tibble::as_tibble(
-      SummarizedExperiment::rowData(exp),
-      rownames = "variable"
-    ))
+    return(.as_info_tibble(SummarizedExperiment::rowData(exp), "variable"))
   }
   glyexp::get_var_info(exp)
+}
+
+#' Convert row or column data to a tibble with an identifier
+#'
+#' @param info A `DataFrame` containing row or column metadata.
+#' @param id The identifier column name to use when `info` does not already
+#'   contain it.
+#'
+#' @returns A tibble that preserves an existing identifier column or adds row
+#'   names under `id`.
+#' @noRd
+.as_info_tibble <- function(info, id) {
+  if (id %in% colnames(info)) {
+    return(tibble::as_tibble(info))
+  }
+  tibble::as_tibble(info, rownames = id)
 }
 
 #' Extract metadata from a glystats data container

--- a/man/filter_sig_vars.Rd
+++ b/man/filter_sig_vars.Rd
@@ -81,7 +81,8 @@ filter_sig_vars(
 )
 }
 \arguments{
-\item{exp}{An \code{\link[glyexp:experiment]{glyexp::experiment()}}. Please use the same experiment used to generate the DEA result.}
+\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} or \code{SummarizedExperiment} object. Use the
+same object used to generate the DEA result.}
 
 \item{res}{A glystats result object from a glystats DEA function.}
 
@@ -107,7 +108,7 @@ If not provided, filtering will be performed on the main test results for \code{
 and variables will be kept if they are significant in any comparison for \code{\link[=gly_limma]{gly_limma()}}.}
 }
 \value{
-An new \code{\link[glyexp:experiment]{glyexp::experiment()}} object.
+A filtered object of the same class as \code{exp}.
 }
 \description{
 Filtering the experiment to keep only significant variables is a common task.

--- a/man/gly_ancova.Rd
+++ b/man/gly_ancova.Rd
@@ -14,7 +14,8 @@ gly_ancova(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_anova.Rd
+++ b/man/gly_anova.Rd
@@ -7,7 +7,8 @@
 gly_anova(exp, group_col = "group", p_adj_method = "BH", add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_cor.Rd
+++ b/man/gly_cor.Rd
@@ -7,7 +7,8 @@
 gly_cor(exp, on = "variable", method = "pearson", p_adj_method = "BH", ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{on}{A character string specifying what to correlate. Either "variable" (default) to correlate
 variables/features, or "sample" to correlate samples/observations.}

--- a/man/gly_cox.Rd
+++ b/man/gly_cox.Rd
@@ -14,7 +14,8 @@ gly_cox(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{time_col}{A character string specifying the column name in sample information
 that contains survival time. Default is "time".}

--- a/man/gly_fold_change.Rd
+++ b/man/gly_fold_change.Rd
@@ -7,7 +7,7 @@
 gly_fold_change(exp, group_col = "group", add_info = TRUE)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object.}
 
 \item{group_col}{The column name of the group information in the sample information.}
 

--- a/man/gly_hclust.Rd
+++ b/man/gly_hclust.Rd
@@ -14,7 +14,8 @@ gly_hclust(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{on}{A character string specifying what to cluster. Either "variable" (default) to cluster
 variables/features, or "sample" to cluster samples/observations.}

--- a/man/gly_kmeans.Rd
+++ b/man/gly_kmeans.Rd
@@ -14,7 +14,8 @@ gly_kmeans(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{on}{A character string specifying what to cluster. Either "variable" (default) to cluster
 variables/features, or "sample" to cluster samples/observations.}

--- a/man/gly_kruskal.Rd
+++ b/man/gly_kruskal.Rd
@@ -13,7 +13,8 @@ gly_kruskal(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_limma.Rd
+++ b/man/gly_limma.Rd
@@ -17,7 +17,8 @@ gly_limma(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp_experiment} object containing expression data and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+expression data and sample information.}
 
 \item{group_col}{A character string specifying the column name in sample information
 that contains group labels. Default is "group".}

--- a/man/gly_oplsda.Rd
+++ b/man/gly_oplsda.Rd
@@ -15,7 +15,8 @@ gly_oplsda(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name in sample information
 that contains group labels. Default is "group".}

--- a/man/gly_pca.Rd
+++ b/man/gly_pca.Rd
@@ -7,7 +7,8 @@
 gly_pca(exp, center = TRUE, scale = TRUE, add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{center}{A logical indicating whether to center the data. Default is TRUE.}
 

--- a/man/gly_plsda.Rd
+++ b/man/gly_plsda.Rd
@@ -14,7 +14,8 @@ gly_plsda(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name in sample information
 that contains group labels. Default is "group".}

--- a/man/gly_roc.Rd
+++ b/man/gly_roc.Rd
@@ -7,7 +7,8 @@
 gly_roc(exp, group_col = "group", pos_class = NULL, add_info = TRUE)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}. The grouping variable must have

--- a/man/gly_tsne.Rd
+++ b/man/gly_tsne.Rd
@@ -7,7 +7,8 @@
 gly_tsne(exp, dims = 2, perplexity = 30, add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{dims}{Number of output dimensions. Default is 2.}
 

--- a/man/gly_ttest.Rd
+++ b/man/gly_ttest.Rd
@@ -14,7 +14,8 @@ gly_ttest(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_umap.Rd
+++ b/man/gly_umap.Rd
@@ -7,7 +7,8 @@
 gly_umap(exp, n_neighbors = 15, n_components = 2, add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{n_neighbors}{Number of neighbors to consider for each point. Default is 15.}
 

--- a/man/gly_wilcox.Rd
+++ b/man/gly_wilcox.Rd
@@ -14,7 +14,8 @@ gly_wilcox(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} object containing expression matrix and sample information.}
+\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
+an expression matrix and sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/glystats-package.Rd
+++ b/man/glystats-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Provides a unified toolbox for bioinformatics analyses of glycomics and glycoproteomics data. Implemented methods include differential testing (t-test, Wilcoxon rank-sum test, ANOVA, Kruskal–Wallis), multivariate modeling and visualization (PCA, t-SNE, UMAP), supervised learning (PLS-DA, OPLS-DA), clustering (k-means, hierarchical, consensus clustering), network analysis (weighted gene co-expression network analysis, WGCNA), survival modeling (Cox proportional hazards), correlation analysis, and ROC/AUC evaluation. All user-facing functions follow the gly_*() naming convention to facilitate auto-completion in RStudio. Analysis functions accept 'glyexp' experiment objects as their unified data interface.
+Provides a unified toolbox for bioinformatics analyses of glycomics and glycoproteomics data. Implemented methods include differential testing (t-test, Wilcoxon rank-sum test, ANOVA, Kruskal–Wallis), multivariate modeling and visualization (PCA, t-SNE, UMAP), supervised learning (PLS-DA, OPLS-DA), clustering (k-means, hierarchical, consensus clustering), network analysis (weighted gene co-expression network analysis, WGCNA), survival modeling (Cox proportional hazards), correlation analysis, and ROC/AUC evaluation. All user-facing functions follow the gly_*() naming convention to facilitate auto-completion in RStudio. Analysis functions accept 'glyexp' experiment and 'SummarizedExperiment' objects as their unified data interface.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,3 +1,18 @@
+as_test_se <- function(exp) {
+  if (methods::is(exp, "SummarizedExperiment")) {
+    return(exp)
+  }
+
+  switch(
+    glyexp::get_exp_type(exp),
+    glycomics = glyexp::as_glycomic_se(exp),
+    glycoproteomics = glyexp::as_glycoproteomic_se(exp),
+    glyexp::as_se(exp)
+  )
+}
+
+test_gp_se <- glyexp::as_glycoproteomic_se(test_gp_exp)
+
 exp_2groups <- function() {
   glyexp::filter_obs(test_gp_exp, group %in% c("C", "H"))
 }
@@ -51,7 +66,8 @@ exp_topliss_valid <- function() {
   rownames(var_info) <- rownames(expr_mat)
 
   # Create glyexp object
-  glyexp::experiment(expr_mat, sample_info, var_info, "others")
+  glyexp::experiment(expr_mat, sample_info, var_info, "others") |>
+    glyexp::as_se()
 }
 
 # Create a multi-group dataset that satisfies Topliss ratio
@@ -107,5 +123,6 @@ exp_multigroup_valid <- function() {
     sample_info = sample_info,
     var_info = var_info,
     exp_type = "others"
-  )
+  ) |>
+    glyexp::as_se()
 }

--- a/tests/testthat/test-add-info.R
+++ b/tests/testthat/test-add-info.R
@@ -2,7 +2,8 @@ test_that("add_info parameter works correctly for functions returning tibbles wi
   # Use test_gp_exp and filter to 2 groups
   exp_2group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("C", "H")) |>
-    glyexp::slice_sample_var(n = 5)
+    glyexp::slice_sample_var(n = 5) |>
+    as_test_se()
 
   # Test gly_fold_change
   result_no_info <- suppressMessages(gly_fold_change(
@@ -35,7 +36,8 @@ test_that("add_info parameter works correctly for functions returning tibbles wi
 test_that("add_info parameter works correctly for functions returning tibbles with sample column", {
   # Use test_gp_exp
   exp_subset <- test_gp_exp |>
-    glyexp::slice_sample_var(n = 10)
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se()
 
   # Test gly_pca
   result_pca_no_info <- suppressMessages(gly_pca(exp_subset, add_info = FALSE))

--- a/tests/testthat/test-ancova.R
+++ b/tests/testthat/test-ancova.R
@@ -5,7 +5,8 @@ test_that("gly_ancova works with ancova method", {
   exp_3group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("C", "H", "M")) |>
     glyexp::slice_sample_var(n = 10) |>
-    glyexp::mutate_obs(covar = seq_along(.data$group))
+    glyexp::mutate_obs(covar = seq_along(.data$group)) |>
+    as_test_se()
 
   # Run DEA with ANCOVA
   result <- suppressMessages(gly_ancova(exp_3group, covariate_cols = "covar"))

--- a/tests/testthat/test-anova.R
+++ b/tests/testthat/test-anova.R
@@ -2,7 +2,8 @@ test_that("gly_anova works with anova method", {
   # Use test_gp_exp with 3 groups for ANOVA
   exp_3group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("C", "H", "M")) |>
-    glyexp::slice_sample_var(n = 10)
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se()
 
   # Run DEA with ANOVA
   result <- suppressMessages(gly_anova(exp_3group))
@@ -214,9 +215,10 @@ test_that("gly_anova assigns NA for failed variables", {
   # The first three variables are set to NA
   exp_3group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("C", "H", "M")) |>
-    glyexp::slice_sample_var(n = 10)
-  exp_3group$expr_mat[1:3, ] <- NA # This will lead to stats::aov() failing
-  na_vars <- exp_3group$var_info$variable[1:3]
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se()
+  SummarizedExperiment::assay(exp_3group)[1:3, ] <- NA
+  na_vars <- rownames(exp_3group)[1:3]
 
   # Run DEA with ANOVA
   expect_warning(result <- suppressMessages(gly_anova(exp_3group)))

--- a/tests/testthat/test-cor.R
+++ b/tests/testthat/test-cor.R
@@ -1,7 +1,8 @@
 test_that("gly_cor basic functionality works", {
   exp_subset <- test_gp_exp |>
     glyexp::slice_sample_var(n = 5) |>
-    glyexp::slice_sample_obs(n = 6)
+    glyexp::slice_sample_obs(n = 6) |>
+    as_test_se()
 
   result <- suppressMessages(gly_cor(exp_subset))
 

--- a/tests/testthat/test-cox.R
+++ b/tests/testthat/test-cox.R
@@ -27,7 +27,8 @@ test_that("gly_cox works with basic survival data", {
     sample_info = sample_info,
     var_info = var_info,
     exp_type = "others"
-  )
+  ) |>
+    as_test_se()
 
   # Test gly_cox function
   result <- suppressMessages(gly_cox(exp))
@@ -452,7 +453,7 @@ test_that("gly_cox works with test_gp_exp data", {
 
 test_that("gly_cox input validation works", {
   # Test with non-experiment object
-  expect_error(gly_cox("not_an_experiment"), "Assertion on 'exp' failed")
+  expect_error(gly_cox("not_an_experiment"), "SummarizedExperiment")
 
   # Test .analyze_cox with invalid inputs
   expr_mat <- matrix(rnorm(20), nrow = 4, ncol = 5)

--- a/tests/testthat/test-filter-sig-vars.R
+++ b/tests/testthat/test-filter-sig-vars.R
@@ -4,7 +4,8 @@ small_exp <- function() {
     glyexp::slice_head_var(n = 10) |>
     glyexp::mutate_obs(
       group = factor(.data$group, levels = c("H", "M", "Y", "C"))
-    )
+    ) |>
+    as_test_se()
 }
 
 # ----- ANOVA main test results -----
@@ -29,6 +30,7 @@ test_that("filter_sig_vars works for ANOVA with default settings", {
   result$tidy_result$main_test$p_adj <- c(rep(0.01, 5), rep(1, 5))
   sig_exp <- filter_sig_vars(exp, result)
   expect_equal(nrow(sig_exp), 5)
+  expect_s4_class(sig_exp, "GlycoproteomicSE")
 })
 
 test_that("filter_sig_vars works for ANOVA with p_val_cutoff", {
@@ -158,7 +160,8 @@ small_exp2 <- function() {
   test_gp_exp |>
     glyexp::slice_head_var(n = 10) |>
     glyexp::filter_obs(.data$group %in% c("C", "H")) |>
-    glyexp::mutate_obs(group = factor(.data$group, levels = c("H", "C")))
+    glyexp::mutate_obs(group = factor(.data$group, levels = c("H", "C"))) |>
+    as_test_se()
 }
 
 # ----- t-test results -----

--- a/tests/testthat/test-fold-change.R
+++ b/tests/testthat/test-fold-change.R
@@ -2,7 +2,8 @@ test_that("gly_fold_change works with basic 2-group comparison", {
   # Use test_gp_exp and filter to 2 groups
   exp_2group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("C", "H")) |>
-    glyexp::slice_sample_var(n = 10) # Use smaller subset for faster testing
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se() # Use smaller subset for faster testing
 
   # Run fold change calculation with add_info = FALSE for basic test
   result <- suppressMessages(gly_fold_change(exp_2group, add_info = FALSE))
@@ -18,7 +19,7 @@ test_that("gly_fold_change works with basic 2-group comparison", {
   # Check that all variables are included
   expect_setequal(
     result$tidy_result$variable,
-    glyexp::get_var_info(exp_2group)$variable
+    rownames(exp_2group)
   )
 
   # Test with add_info = TRUE (default)

--- a/tests/testthat/test-get-res.R
+++ b/tests/testthat/test-get-res.R
@@ -1,25 +1,25 @@
 test_that("get_tidy_result works", {
-  result <- suppressMessages(gly_anova(test_gp_exp))
+  result <- suppressMessages(gly_anova(test_gp_se))
   expect_s3_class(get_tidy_result(result, "main_test"), "tbl_df")
 })
 
 test_that("get_raw_result works", {
-  result <- suppressMessages(gly_anova(test_gp_exp))
+  result <- suppressMessages(gly_anova(test_gp_se))
   expect_type(get_raw_result(result), "list")
 })
 
 test_that("get_tidy_result raises error if which is not in tidy_result", {
-  result <- suppressMessages(gly_anova(test_gp_exp))
+  result <- suppressMessages(gly_anova(test_gp_se))
   expect_error(get_tidy_result(result, "nonexistent"), "must be one of")
 })
 
 test_that("get_tidy_result raises error if tidy_result is a list but no `which` is provided", {
-  result <- suppressMessages(gly_anova(test_gp_exp))
+  result <- suppressMessages(gly_anova(test_gp_se))
   expect_error(get_tidy_result(result), "must be provided for")
 })
 
 test_that("get_tidy_result works when tidy_result is already a tibble", {
-  result <- suppressMessages(gly_fold_change(test_gp_exp))
+  result <- suppressMessages(gly_fold_change(test_gp_se))
   expect_no_error(tidy_result <- get_tidy_result(result))
   expect_s3_class(tidy_result, "tbl_df")
 })

--- a/tests/testthat/test-hclust.R
+++ b/tests/testthat/test-hclust.R
@@ -10,7 +10,8 @@ test_that("gly_hclust does not leak graphics devices when ggdendro is available"
 
   exp_subset <- test_gp_exp |>
     glyexp::slice_sample_var(n = 5) |>
-    glyexp::slice_sample_obs(n = 5)
+    glyexp::slice_sample_obs(n = 5) |>
+    as_test_se()
 
   suppressMessages(gly_hclust(exp_subset, on = "sample", k_values = c(2)))
 

--- a/tests/testthat/test-input-contract.R
+++ b/tests/testthat/test-input-contract.R
@@ -51,3 +51,20 @@ test_that("plain SummarizedExperiment inputs do not require glyexp subclasses", 
   expect_s3_class(result, "glystats_pca_res")
   expect_equal(result$meta_data, S4Vectors::metadata(se))
 })
+
+test_that("SummarizedExperiment inputs preserve existing identifier columns", {
+  se <- methods::as(test_gp_se, "SummarizedExperiment")
+  SummarizedExperiment::colData(se)$sample <- colnames(se)
+  SummarizedExperiment::rowData(se)$variable <- rownames(se)
+
+  result <- gly_pca(se)
+
+  expect_setequal(
+    result$tidy_result$samples$sample,
+    SummarizedExperiment::colData(se)$sample
+  )
+  expect_setequal(
+    result$tidy_result$variables$variable,
+    SummarizedExperiment::rowData(se)$variable
+  )
+})

--- a/tests/testthat/test-input-contract.R
+++ b/tests/testthat/test-input-contract.R
@@ -1,4 +1,4 @@
-test_that("analysis functions use experiment inputs", {
+test_that("analysis functions use a unified data-container input", {
   analysis_functions <- grep(
     "^gly_",
     getNamespaceExports("glystats"),
@@ -15,7 +15,39 @@ test_that("analysis functions use experiment inputs", {
 test_that("analysis functions reject matrix inputs", {
   expr_mat <- matrix(1:4, nrow = 2)
 
-  expect_error(gly_fold_change(expr_mat), "glyexp_experiment")
-  expect_error(gly_pca(expr_mat), "glyexp_experiment")
-  expect_error(gly_cox(expr_mat), "glyexp_experiment")
+  expect_error(gly_fold_change(expr_mat), "SummarizedExperiment")
+  expect_error(gly_pca(expr_mat), "SummarizedExperiment")
+  expect_error(gly_cox(expr_mat), "SummarizedExperiment")
+})
+
+test_that("analysis functions support SummarizedExperiment natively", {
+  se <- glyexp::as_glycoproteomic_se(test_gp_exp)
+  two_group_se <- se[, SummarizedExperiment::colData(se)$group %in% c("C", "H")]
+
+  pca_result <- gly_pca(se)
+  fold_change_result <- suppressMessages(gly_fold_change(two_group_se))
+
+  expect_s4_class(se, "GlycoproteomicSE")
+  expect_s3_class(pca_result, "glystats_pca_res")
+  expect_s3_class(fold_change_result, "glystats_fc_res")
+  expect_equal(pca_result$meta_data, S4Vectors::metadata(se))
+  expect_true("protein" %in% names(fold_change_result$tidy_result))
+})
+
+test_that("plain SummarizedExperiment inputs do not require glyexp subclasses", {
+  glyco_se <- glyexp::as_glycomic_se(glyexp::real_experiment2)
+  abundance <- SummarizedExperiment::assay(glyco_se)
+  complete_rows <- rowSums(!is.finite(abundance)) == 0
+  varying_rows <- apply(abundance, 1, stats::var) > 0
+  se <- methods::as(
+    glyco_se[complete_rows & varying_rows, ],
+    "SummarizedExperiment"
+  )
+
+  result <- gly_pca(se)
+
+  expect_s4_class(se, "SummarizedExperiment")
+  expect_false(methods::is(se, "GlycomicSE"))
+  expect_s3_class(result, "glystats_pca_res")
+  expect_equal(result$meta_data, S4Vectors::metadata(se))
 })

--- a/tests/testthat/test-kmeans.R
+++ b/tests/testthat/test-kmeans.R
@@ -2,7 +2,8 @@ test_that("gly_kmeans works with basic parameters", {
   # Use a subset of test data for faster testing
   exp_subset <- test_gp_exp |>
     glyexp::slice_sample_var(n = 10) |>
-    glyexp::slice_sample_obs(n = 8)
+    glyexp::slice_sample_obs(n = 8) |>
+    as_test_se()
 
   result <- suppressMessages(gly_kmeans(exp_subset))
 

--- a/tests/testthat/test-limma.R
+++ b/tests/testthat/test-limma.R
@@ -4,7 +4,8 @@ test_that("gly_limma works with 2 groups", {
   # Use test_gp_exp and filter to 2 groups for limma
   exp_2group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("C", "H")) |>
-    glyexp::slice_sample_var(n = 10) # Use smaller subset for faster testing
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se() # Use smaller subset for faster testing
 
   # Run DEA with limma
   result <- suppressMessages(gly_limma(exp_2group))

--- a/tests/testthat/test-oplsda.R
+++ b/tests/testthat/test-oplsda.R
@@ -287,8 +287,8 @@ test_that(".analyze_oplsda works correctly", {
   skip_if_not_installed("ropls")
 
   exp <- exp_topliss_valid()
-  expr_mat <- glyexp::get_expr_mat(exp)
-  groups <- factor(glyexp::get_sample_info(exp)$group)
+  expr_mat <- SummarizedExperiment::assay(exp)
+  groups <- factor(SummarizedExperiment::colData(exp)$group)
 
   # Test function execution
   suppressMessages(suppressWarnings({

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -1,7 +1,7 @@
 test_that("gly_pca works", {
   # Note: this integration test only makes sure the function runs,
   # it doesn't promise the result is correct.
-  pca_res <- gly_pca(test_gp_exp)
+  pca_res <- gly_pca(test_gp_se)
   expect_s3_class(pca_res, c("glystats_pca_res", "glystats_res"))
   expect_type(pca_res, "list")
   expect_setequal(names(pca_res), c("tidy_result", "raw_result", "meta_data"))
@@ -49,10 +49,10 @@ test_that(".analyze_pca works correctly", {
 
 test_that("gly_pca add_info works", {
   # Test with add_info = TRUE (default)
-  pca_with_info <- gly_pca(test_gp_exp, add_info = TRUE)
+  pca_with_info <- gly_pca(test_gp_se, add_info = TRUE)
 
   # Test with add_info = FALSE
-  pca_without_info <- gly_pca(test_gp_exp, add_info = FALSE)
+  pca_without_info <- gly_pca(test_gp_se, add_info = FALSE)
 
   # Results should be different when add_info is different
   expect_false(identical(
@@ -102,7 +102,7 @@ test_that(".analyze_pca handles all constant columns", {
   )
 })
 
-test_that("gly_pca returns meta_data from experiment", {
+test_that("gly_pca keeps experiment compatibility", {
   # Create a simple experiment with metadata
   expr_mat <- matrix(runif(20), nrow = 5, ncol = 4)
   colnames(expr_mat) <- c("S1", "S2", "S3", "S4")

--- a/tests/testthat/test-roc.R
+++ b/tests/testthat/test-roc.R
@@ -1,7 +1,8 @@
 test_that("gly_roc works with 2-group binary classification", {
   # Use test_gp_exp and filter to 2 groups for ROC analysis
   exp_2group <- exp_2groups() |>
-    glyexp::slice_sample_var(n = 10) # Use smaller subset for faster testing
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se() # Use smaller subset for faster testing
 
   # Run ROC analysis
   result <- suppressMessages(gly_roc(

--- a/tests/testthat/test-tsne.R
+++ b/tests/testthat/test-tsne.R
@@ -4,7 +4,7 @@ test_that("gly_tsne works with default parameters", {
   skip_if_not_installed("Rtsne")
 
   # Use appropriate perplexity for small dataset to avoid warnings
-  result <- gly_tsne(test_gp_exp, perplexity = 3)
+  result <- gly_tsne(test_gp_se, perplexity = 3)
 
   # Check basic structure
   expect_s3_class(result, c("glystats_tsne_res", "glystats_res"))
@@ -13,7 +13,7 @@ test_that("gly_tsne works with default parameters", {
 
   # Check tidy_result structure
   expect_s3_class(result$tidy_result, "tbl_df")
-  expect_equal(nrow(result$tidy_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$tidy_result), ncol(test_gp_se))
   expect_true("tsne1" %in% names(result$tidy_result))
   expect_true("tsne2" %in% names(result$tidy_result))
   expect_true("sample" %in% names(result$tidy_result))
@@ -33,10 +33,10 @@ test_that("gly_tsne works with default parameters", {
 test_that("gly_tsne works with custom parameters", {
   skip_if_not_installed("Rtsne")
 
-  result <- gly_tsne(test_gp_exp, perplexity = 2, max_iter = 250)
+  result <- gly_tsne(test_gp_se, perplexity = 2, max_iter = 250)
 
   expect_s3_class(result, c("glystats_tsne_res", "glystats_res"))
-  expect_equal(nrow(result$tidy_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$tidy_result), ncol(test_gp_se))
   expect_true(all(c("tsne1", "tsne2", "sample") %in% names(result$tidy_result)))
 })
 
@@ -45,12 +45,12 @@ test_that("gly_tsne handles perplexity adjustment", {
 
   # Should work and adjust perplexity automatically when too large
   expect_warning(
-    result <- suppressMessages(gly_tsne(test_gp_exp, perplexity = 15)),
+    result <- suppressMessages(gly_tsne(test_gp_se, perplexity = 15)),
     "Perplexity should be smaller"
   )
 
   expect_s3_class(result, c("glystats_tsne_res", "glystats_res"))
-  expect_equal(nrow(result$tidy_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$tidy_result), ncol(test_gp_se))
 })
 
 test_that("gly_tsne works with default perplexity", {
@@ -58,23 +58,23 @@ test_that("gly_tsne works with default perplexity", {
 
   # Test with default perplexity (30) - should trigger warning and adjustment
   expect_warning(
-    result <- suppressMessages(gly_tsne(test_gp_exp)),
+    result <- suppressMessages(gly_tsne(test_gp_se)),
     "Perplexity should be smaller"
   )
 
   expect_s3_class(result, c("glystats_tsne_res", "glystats_res"))
-  expect_equal(nrow(result$tidy_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$tidy_result), ncol(test_gp_se))
 })
 
 test_that("gly_tsne has consistent sample names", {
   skip_if_not_installed("Rtsne")
 
-  result <- gly_tsne(test_gp_exp, perplexity = 3)
+  result <- gly_tsne(test_gp_se, perplexity = 3)
 
   # Should have same sample names as input expression matrix
   expect_equal(
     sort(result$tidy_result$sample),
-    sort(colnames(test_gp_exp$expr_mat))
+    sort(colnames(test_gp_se))
   )
 })
 

--- a/tests/testthat/test-ttest.R
+++ b/tests/testthat/test-ttest.R
@@ -2,7 +2,8 @@ test_that("gly_ttest works with t-test method", {
   # Use test_gp_exp and filter to 2 groups for t-test
   exp_2group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("C", "H")) |>
-    glyexp::slice_sample_var(n = 10) # Use smaller subset for faster testing
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se() # Use smaller subset for faster testing
 
   # Run DEA with t-test
   result <- suppressMessages(gly_ttest(exp_2group))
@@ -49,7 +50,8 @@ test_that("gly_wilcox works with wilcoxon method", {
   # Use test_gp_exp and filter to 2 groups for wilcoxon test
   exp_2group <- test_gp_exp |>
     glyexp::filter_obs(group %in% c("M", "Y")) |>
-    glyexp::slice_sample_var(n = 10) # Use smaller subset for faster testing
+    glyexp::slice_sample_var(n = 10) |>
+    as_test_se() # Use smaller subset for faster testing
 
   # Run DEA with wilcoxon test
   result <- suppressMessages(suppressWarnings(gly_wilcox(exp_2group)))

--- a/tests/testthat/test-umap.R
+++ b/tests/testthat/test-umap.R
@@ -4,7 +4,7 @@ test_that("gly_umap works with default parameters", {
   skip_if_not_installed("uwot")
 
   # Use appropriate n_neighbors for small dataset
-  result <- gly_umap(test_gp_exp, n_neighbors = 3)
+  result <- gly_umap(test_gp_se, n_neighbors = 3)
 
   # Check basic structure
   expect_s3_class(result, c("glystats_umap_res", "glystats_res"))
@@ -13,7 +13,7 @@ test_that("gly_umap works with default parameters", {
 
   # Check tidy_result structure
   expect_s3_class(result$tidy_result, "tbl_df")
-  expect_equal(nrow(result$tidy_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$tidy_result), ncol(test_gp_se))
   expect_true("umap1" %in% names(result$tidy_result))
   expect_true("umap2" %in% names(result$tidy_result))
   expect_true("sample" %in% names(result$tidy_result))
@@ -28,7 +28,7 @@ test_that("gly_umap works with default parameters", {
 
   # Check raw_result
   expect_true(is.matrix(result$raw_result))
-  expect_equal(nrow(result$raw_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$raw_result), ncol(test_gp_se))
   expect_equal(ncol(result$raw_result), 2)
 })
 
@@ -36,24 +36,24 @@ test_that("gly_umap works with custom parameters", {
   skip_if_not_installed("uwot")
 
   result <- gly_umap(
-    test_gp_exp,
+    test_gp_se,
     n_neighbors = 2,
     min_dist = 0.01,
     n_epochs = 50
   )
 
   expect_s3_class(result, c("glystats_umap_res", "glystats_res"))
-  expect_equal(nrow(result$tidy_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$tidy_result), ncol(test_gp_se))
   expect_true(all(c("umap1", "umap2", "sample") %in% names(result$tidy_result)))
 })
 
 test_that("gly_umap works with more than 2 components", {
   skip_if_not_installed("uwot")
 
-  result <- gly_umap(test_gp_exp, n_neighbors = 3, n_components = 3)
+  result <- gly_umap(test_gp_se, n_neighbors = 3, n_components = 3)
 
   expect_s3_class(result, c("glystats_umap_res", "glystats_res"))
-  expect_equal(nrow(result$tidy_result), nrow(test_gp_exp$sample_info))
+  expect_equal(nrow(result$tidy_result), ncol(test_gp_se))
   expect_true(all(
     c("umap1", "umap2", "umap3", "sample") %in% names(result$tidy_result)
   ))
@@ -70,12 +70,12 @@ test_that("gly_umap works with more than 2 components", {
 test_that("gly_umap has consistent sample names", {
   skip_if_not_installed("uwot")
 
-  result <- gly_umap(test_gp_exp, n_neighbors = 3)
+  result <- gly_umap(test_gp_se, n_neighbors = 3)
 
   # Should have same sample names as input expression matrix
   expect_equal(
     sort(result$tidy_result$sample),
-    sort(colnames(test_gp_exp$expr_mat))
+    sort(colnames(test_gp_se))
   )
 })
 


### PR DESCRIPTION
## Summary

Add native `SummarizedExperiment` support across glystats analysis functions while preserving the existing `glyexp::experiment()` interface.

## Background

This is the glystats Stage I interoperability work for the gradual `glyexp` container migration. Documentation continues to use `experiment()` examples; this PR adds the new input type without recommending it yet.

## Details

- add a shared native adapter for the first assay, `colData`, `rowData`, and `metadata`
- accept `SummarizedExperiment` in all 17 `gly_*()` analysis functions and preserve input class in `filter_sig_vars()`
- preserve existing `sample` and `variable` identifier columns when adapting SE metadata
- keep `glyexp::experiment()` compatibility unchanged
- add `SummarizedExperiment`, `S4Vectors`, and `methods` as direct runtime dependencies
- update generated function documentation while leaving README and vignette examples on `experiment()`
- migrate representative integration coverage to `GlycomicSE`, `GlycoproteomicSE`, and plain `SummarizedExperiment`

## Verification

- `Rscript -e 'devtools::test(filter = "input-contract")'` — 32 passed, 0 failed
- `Rscript -e 'devtools::test()'` — 870 passed, 0 failed, 0 warnings, 0 skipped
- `Rscript -e 'Sys.setenv(`_R_CHECK_SYSTEM_CLOCK_` = "false"); devtools::check()'` — 0 errors, 0 warnings, 0 notes
- `git diff --check`

Closes #11