### PR TITLE
Recommend Stage II glyexp containers in documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,8 @@ Description: Provides a unified toolbox for bioinformatics analyses of glycomics
     (Cox proportional hazards), correlation analysis, and ROC/AUC evaluation.
     All user-facing functions follow the gly_*() naming
     convention to facilitate auto-completion in RStudio. Analysis functions
-    accept 'glyexp' experiment and 'SummarizedExperiment' objects as their
-    unified data interface.
+    accept 'glyexp' 'GlycomicSE', 'GlycoproteomicSE', and
+    'SummarizedExperiment' objects as their unified data interface.
 License: MIT + file LICENSE
 Suggests:
     testthat (>= 3.0.0),
@@ -40,7 +40,7 @@ RoxygenNote: 7.3.3
 URL: https://glycoverse.github.io/glystats/
 Imports:
     tibble,
-    glyexp (>= 0.15.0),
+    glyexp (>= 0.16.0),
     rlang,
     tidyr,
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # glystats (development version)
 
-* Documentation and vignettes now recommend `GlycomicSE` and `GlycoproteomicSE` containers with `SummarizedExperiment` accessors for Stage II of glycoverse/glyexp#15.
+* Documentation and vignettes now recommend `GlycomicSE` and `GlycoproteomicSE` containers with `SummarizedExperiment` accessors for Stage II of glycoverse/glyexp#15. (#15)
 
 # glystats 0.11.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # glystats (development version)
 
+* Documentation and vignettes now recommend `GlycomicSE` and `GlycoproteomicSE` containers with `SummarizedExperiment` accessors for Stage II of glycoverse/glyexp#15.
+
 # glystats 0.11.1
 
 * Statistical analysis functions now recognize legacy `glyexp::experiment()` and current `SummarizedExperiment` containers consistently across supported `glyexp` versions.

--- a/R/anova.R
+++ b/R/anova.R
@@ -5,8 +5,9 @@
 #' For significant results, Tukey's HSD post-hoc test is automatically performed.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.
@@ -184,8 +185,9 @@ gly_anova <- function(
 #' For significant results, emmeans post-hoc comparisons (Tukey adjustment) are automatically performed.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param covariate_cols A character vector specifying column names in sample information
@@ -410,8 +412,9 @@ gly_ancova <- function(
 #' For significant results, Dunn's post-hoc test is automatically performed.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.

--- a/R/cor.R
+++ b/R/cor.R
@@ -4,8 +4,9 @@
 #' The function calculates correlation coefficients and p-values for all pairs,
 #' with optional multiple testing correction.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param on A character string specifying what to correlate. Either "variable" (default) to correlate
 #'   variables/features, or "sample" to correlate samples/observations.
 #' @param method A character string indicating which correlation coefficient is to be computed.

--- a/R/cox.R
+++ b/R/cox.R
@@ -3,8 +3,9 @@
 #' Fit a Cox proportional hazards model for each variable in the expression data,
 #' and extract p-values and hazard ratios from it.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param time_col A character string specifying the column name in sample information
 #'   that contains survival time. Default is "time".
 #' @param event_col A character string specifying the column name in sample information

--- a/R/filter-sig-vars.R
+++ b/R/filter-sig-vars.R
@@ -5,8 +5,9 @@
 #' It supports results from all glystats DEA functions including
 #' [gly_anova()], [gly_ancova()], [gly_kruskal()], [gly_ttest()], [gly_wilcox()], and [gly_limma()].
 #'
-#' @param exp A [glyexp::experiment()] or `SummarizedExperiment` object. Use the
-#'   same object used to generate the DEA result.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment`. Use the same object used to generate the
+#'   DEA result.
 #' @param res A glystats result object from a glystats DEA function.
 #' @param p_adj_cutoff The threshold for p-adjusted values. Default is 0.05.
 #' @param p_val_cutoff The threshold for p-values. We don't recommend using this. Default is NULL.
@@ -23,7 +24,7 @@
 #' library(glyclean)
 #'
 #' exp <- auto_clean(real_experiment) |>
-#'   glyexp::slice_head_var(n = 10)
+#'   glyexp::slice_head_row(n = 10)
 #' res <- gly_anova(exp)
 #' sig_exp <- filter_sig_vars(exp, res)
 #'

--- a/R/fold-change.R
+++ b/R/fold-change.R
@@ -5,7 +5,8 @@
 #' When you run this function, you will see message about "Ref Group" and "Test Group".
 #' "Ref Group" is the reference group, and "Test Group" is the test/treatment/case group.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment`.
 #' @param group_col The column name of the group information in the sample information.
 #' @param add_info A logical value. If TRUE (default), variable information from the experiment
 #'  will be added to the result tibble. If FALSE, only the fold change results are returned.

--- a/R/get-res.R
+++ b/R/get-res.R
@@ -16,7 +16,7 @@
 #' library(dplyr)
 #'
 #' exp <- auto_clean(real_experiment) |>
-#'   glyexp::slice_head_var(n = 10)
+#'   glyexp::slice_head_row(n = 10)
 #'
 #' # Using a pipe
 #' sig_res <- exp |>

--- a/R/hclust.R
+++ b/R/hclust.R
@@ -5,8 +5,9 @@
 #' tidy results including cluster assignments, dendrogram data for plotting,
 #' and merge heights.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param on A character string specifying what to cluster. Either "variable" (default) to cluster
 #'   variables/features, or "sample" to cluster samples/observations.
 #' @param k_values A numeric vector specifying the number of clusters to cut the tree into.

--- a/R/kmeans.R
+++ b/R/kmeans.R
@@ -4,8 +4,9 @@
 #' The function uses `stats::kmeans()` to perform clustering and provides
 #' tidy results with cluster assignments.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param on A character string specifying what to cluster. Either "variable" (default) to cluster
 #'   variables/features, or "sample" to cluster samples/observations.
 #' @param centers Either the number of clusters (integer) or a set of initial cluster centers.

--- a/R/limma.R
+++ b/R/limma.R
@@ -3,8 +3,9 @@
 #' Perform differential expression analysis using linear models with empirical Bayes
 #' moderation from the limma package. Supports both two-group and multi-group comparisons.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   expression data and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing expression data and sample
+#'   information.
 #' @param group_col A character string specifying the column name in sample information
 #'   that contains group labels. Default is "group".
 #' @param covariate_cols A character vector specifying column names in sample information

--- a/R/oplsda.R
+++ b/R/oplsda.R
@@ -3,8 +3,9 @@
 #' Perform orthogonal partial least squares discriminant analysis on the expression data.
 #' The function uses `ropls::opls()` to perform OPLS-DA and returns tidy results.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name in sample information
 #'   that contains group labels. Default is "group".
 #' @param pred_i An integer indicating the number of predictive components to include. Default is 1.

--- a/R/pca.R
+++ b/R/pca.R
@@ -4,8 +4,9 @@
 #' The function uses `prcomp()` to perform PCA and `broom::tidy()` to tidy the results.
 #' If `scale = TRUE`, constant variables (zero variance) will be removed before PCA.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param center A logical indicating whether to center the data. Default is TRUE.
 #' @param scale A logical indicating whether to scale the data. Default is TRUE.
 #' @param add_info A logical value. If TRUE (default), sample and variable information from the experiment

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -3,8 +3,9 @@
 #' Perform partial least squares discriminant analysis on the expression data.
 #' The function uses `ropls::opls()` to perform PLS-DA and returns tidy results.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name in sample information
 #'   that contains group labels. Default is "group".
 #' @param ncomp An integer indicating the number of components to include. Default is 2.

--- a/R/roc.R
+++ b/R/roc.R
@@ -5,8 +5,9 @@
 #' Area Under the Curve (AUC) values for each variable to assess their discriminatory
 #' power between two groups.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'   in the sample information. Default is `"group"`. The grouping variable must have
 #'   exactly 2 levels for binary classification.

--- a/R/tsne.R
+++ b/R/tsne.R
@@ -3,8 +3,9 @@
 #' Perform t-SNE dimensionality reduction on the expression data.
 #' The function uses `Rtsne::Rtsne()` to perform t-SNE analysis.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param dims Number of output dimensions. Default is 2.
 #' @param perplexity Perplexity parameter for t-SNE. Default is 30.
 #' @param add_info A logical value. If TRUE (default), sample information from the experiment

--- a/R/ttest.R
+++ b/R/ttest.R
@@ -4,8 +4,9 @@
 #' The function supports Student's t-test for comparing two groups.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.
@@ -139,8 +140,9 @@ gly_ttest <- function(
 #' The function supports non-parametric comparison of two groups.
 #' P-values are adjusted for multiple testing using the method specified by `p_adj_method`.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param group_col A character string specifying the column name of the grouping variable
 #'  in the sample information. Default is `"group"`.
 #' @param p_adj_method A character string specifying the method to adjust p-values.

--- a/R/umap.R
+++ b/R/umap.R
@@ -3,8 +3,9 @@
 #' Perform UMAP dimensionality reduction on the expression data.
 #' The function uses `uwot::umap()` to perform UMAP analysis.
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object containing
-#'   an expression matrix and sample information.
+#' @param exp A [glyexp::GlycomicSE()] or [glyexp::GlycoproteomicSE()] object,
+#'   or another `SummarizedExperiment` containing an expression matrix and
+#'   sample information.
 #' @param n_neighbors Number of neighbors to consider for each point. Default is 15.
 #' @param n_components Number of output dimensions. Default is 2.
 #' @param add_info A logical value. If TRUE (default), sample information from the experiment

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,7 +2,8 @@
 
 #' Check a glystats data-container input
 #'
-#' @param exp A `glyexp::experiment()` or `SummarizedExperiment` object.
+#' @param exp A `glyexp::GlycomicSE`, `glyexp::GlycoproteomicSE`, or another
+#'   `SummarizedExperiment` object.
 #'
 #' @returns `NULL` invisibly, or an error if `exp` is unsupported.
 #' @noRd

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,14 +68,16 @@ are also applicable here: [Installation of glycoverse](https://github.com/glycov
 ## Role in `glycoverse`
 
 `glystats` is the downstream analysis package in the `glycoverse` ecosystem.
-It provides statistical analysis functions for `glyexp::experiment()` objects.
+It provides statistical analysis functions for `glyexp::GlycomicSE` and
+`glyexp::GlycoproteomicSE` objects.
 A common workflow is to use [glyread](https://github.com/glycoverse/glyread) to import data,
 [glyclean](https://github.com/glycoverse/glyclean) to preprocess data,
 and then `glystats` to perform statistical analysis.
 
 ## Example
 
-Say we already have a preprocessed experiment object called `exp`:
+Say we already have a preprocessed glycomics or glycoproteomics container
+called `exp`:
 
 ```r
 # Two-sample t-test
@@ -90,6 +92,6 @@ roc_res <- gly_roc(exp)
 
 That's it! These functions use `glycoverse` column conventions to load needed data and perform analysis.
 All functions start with `gly_` to leverage the auto-completion in RStudio.
-They accept an `glyexp::experiment()` object,
+They accept a `glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE` object,
 and return analysis result as a tibble or a list of tibbles.
 See documentation for each function for more details.

--- a/README.md
+++ b/README.md
@@ -69,14 +69,15 @@ glycoverse](https://github.com/glycoverse/glycoverse#installation).
 
 `glystats` is the downstream analysis package in the `glycoverse`
 ecosystem. It provides statistical analysis functions for
-`glyexp::experiment()` objects. A common workflow is to use
-[glyread](https://github.com/glycoverse/glyread) to import data,
-[glyclean](https://github.com/glycoverse/glyclean) to preprocess data,
-and then `glystats` to perform statistical analysis.
+`glyexp::GlycomicSE` and `glyexp::GlycoproteomicSE` objects. A common
+workflow is to use [glyread](https://github.com/glycoverse/glyread) to
+import data, [glyclean](https://github.com/glycoverse/glyclean) to
+preprocess data, and then `glystats` to perform statistical analysis.
 
 ## Example
 
-Say we already have a preprocessed experiment object called `exp`:
+Say we already have a preprocessed glycomics or glycoproteomics
+container called `exp`:
 
 ``` r
 # Two-sample t-test
@@ -91,6 +92,7 @@ roc_res <- gly_roc(exp)
 
 That’s it! These functions use `glycoverse` column conventions to load
 needed data and perform analysis. All functions start with `gly_` to
-leverage the auto-completion in RStudio. They accept an
-`glyexp::experiment()` object, and return analysis result as a tibble or
-a list of tibbles. See documentation for each function for more details.
+leverage the auto-completion in RStudio. They accept a
+`glyexp::GlycomicSE` or `glyexp::GlycoproteomicSE` object, and return
+analysis result as a tibble or a list of tibbles. See documentation for
+each function for more details.

--- a/man/filter_sig_vars.Rd
+++ b/man/filter_sig_vars.Rd
@@ -81,8 +81,9 @@ filter_sig_vars(
 )
 }
 \arguments{
-\item{exp}{A \code{\link[glyexp:experiment]{glyexp::experiment()}} or \code{SummarizedExperiment} object. Use the
-same object used to generate the DEA result.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment}. Use the same object used to generate the
+DEA result.}
 
 \item{res}{A glystats result object from a glystats DEA function.}
 
@@ -121,7 +122,7 @@ library(glyexp)
 library(glyclean)
 
 exp <- auto_clean(real_experiment) |>
-  glyexp::slice_head_var(n = 10)
+  glyexp::slice_head_row(n = 10)
 res <- gly_anova(exp)
 sig_exp <- filter_sig_vars(exp, res)
 

--- a/man/get_tidy_result.Rd
+++ b/man/get_tidy_result.Rd
@@ -29,7 +29,7 @@ library(glyclean)
 library(dplyr)
 
 exp <- auto_clean(real_experiment) |>
-  glyexp::slice_head_var(n = 10)
+  glyexp::slice_head_row(n = 10)
 
 # Using a pipe
 sig_res <- exp |>

--- a/man/gly_ancova.Rd
+++ b/man/gly_ancova.Rd
@@ -14,8 +14,9 @@ gly_ancova(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_anova.Rd
+++ b/man/gly_anova.Rd
@@ -7,8 +7,9 @@
 gly_anova(exp, group_col = "group", p_adj_method = "BH", add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_cor.Rd
+++ b/man/gly_cor.Rd
@@ -7,8 +7,9 @@
 gly_cor(exp, on = "variable", method = "pearson", p_adj_method = "BH", ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{on}{A character string specifying what to correlate. Either "variable" (default) to correlate
 variables/features, or "sample" to correlate samples/observations.}

--- a/man/gly_cox.Rd
+++ b/man/gly_cox.Rd
@@ -14,8 +14,9 @@ gly_cox(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{time_col}{A character string specifying the column name in sample information
 that contains survival time. Default is "time".}

--- a/man/gly_fold_change.Rd
+++ b/man/gly_fold_change.Rd
@@ -7,7 +7,8 @@
 gly_fold_change(exp, group_col = "group", add_info = TRUE)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment}.}
 
 \item{group_col}{The column name of the group information in the sample information.}
 

--- a/man/gly_hclust.Rd
+++ b/man/gly_hclust.Rd
@@ -14,8 +14,9 @@ gly_hclust(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{on}{A character string specifying what to cluster. Either "variable" (default) to cluster
 variables/features, or "sample" to cluster samples/observations.}

--- a/man/gly_kmeans.Rd
+++ b/man/gly_kmeans.Rd
@@ -14,8 +14,9 @@ gly_kmeans(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{on}{A character string specifying what to cluster. Either "variable" (default) to cluster
 variables/features, or "sample" to cluster samples/observations.}

--- a/man/gly_kruskal.Rd
+++ b/man/gly_kruskal.Rd
@@ -13,8 +13,9 @@ gly_kruskal(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_limma.Rd
+++ b/man/gly_limma.Rd
@@ -17,8 +17,9 @@ gly_limma(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-expression data and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing expression data and sample
+information.}
 
 \item{group_col}{A character string specifying the column name in sample information
 that contains group labels. Default is "group".}

--- a/man/gly_oplsda.Rd
+++ b/man/gly_oplsda.Rd
@@ -15,8 +15,9 @@ gly_oplsda(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name in sample information
 that contains group labels. Default is "group".}

--- a/man/gly_pca.Rd
+++ b/man/gly_pca.Rd
@@ -7,8 +7,9 @@
 gly_pca(exp, center = TRUE, scale = TRUE, add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{center}{A logical indicating whether to center the data. Default is TRUE.}
 

--- a/man/gly_plsda.Rd
+++ b/man/gly_plsda.Rd
@@ -14,8 +14,9 @@ gly_plsda(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name in sample information
 that contains group labels. Default is "group".}

--- a/man/gly_roc.Rd
+++ b/man/gly_roc.Rd
@@ -7,8 +7,9 @@
 gly_roc(exp, group_col = "group", pos_class = NULL, add_info = TRUE)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}. The grouping variable must have

--- a/man/gly_tsne.Rd
+++ b/man/gly_tsne.Rd
@@ -7,8 +7,9 @@
 gly_tsne(exp, dims = 2, perplexity = 30, add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{dims}{Number of output dimensions. Default is 2.}
 

--- a/man/gly_ttest.Rd
+++ b/man/gly_ttest.Rd
@@ -14,8 +14,9 @@ gly_ttest(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/gly_umap.Rd
+++ b/man/gly_umap.Rd
@@ -7,8 +7,9 @@
 gly_umap(exp, n_neighbors = 15, n_components = 2, add_info = TRUE, ...)
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{n_neighbors}{Number of neighbors to consider for each point. Default is 15.}
 

--- a/man/gly_wilcox.Rd
+++ b/man/gly_wilcox.Rd
@@ -14,8 +14,9 @@ gly_wilcox(
 )
 }
 \arguments{
-\item{exp}{A \code{glyexp::experiment()} or \code{SummarizedExperiment} object containing
-an expression matrix and sample information.}
+\item{exp}{A \code{\link[glyexp:GlycomicSE]{glyexp::GlycomicSE()}} or \code{\link[glyexp:GlycoproteomicSE]{glyexp::GlycoproteomicSE()}} object,
+or another \code{SummarizedExperiment} containing an expression matrix and
+sample information.}
 
 \item{group_col}{A character string specifying the column name of the grouping variable
 in the sample information. Default is \code{"group"}.}

--- a/man/glystats-package.Rd
+++ b/man/glystats-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Provides a unified toolbox for bioinformatics analyses of glycomics and glycoproteomics data. Implemented methods include differential testing (t-test, Wilcoxon rank-sum test, ANOVA, Kruskal–Wallis), multivariate modeling and visualization (PCA, t-SNE, UMAP), supervised learning (PLS-DA, OPLS-DA), clustering (k-means, hierarchical, consensus clustering), network analysis (weighted gene co-expression network analysis, WGCNA), survival modeling (Cox proportional hazards), correlation analysis, and ROC/AUC evaluation. All user-facing functions follow the gly_*() naming convention to facilitate auto-completion in RStudio. Analysis functions accept 'glyexp' experiment and 'SummarizedExperiment' objects as their unified data interface.
+Provides a unified toolbox for bioinformatics analyses of glycomics and glycoproteomics data. Implemented methods include differential testing (t-test, Wilcoxon rank-sum test, ANOVA, Kruskal–Wallis), multivariate modeling and visualization (PCA, t-SNE, UMAP), supervised learning (PLS-DA, OPLS-DA), clustering (k-means, hierarchical, consensus clustering), network analysis (weighted gene co-expression network analysis, WGCNA), survival modeling (Cox proportional hazards), correlation analysis, and ROC/AUC evaluation. All user-facing functions follow the gly_*() naming convention to facilitate auto-completion in RStudio. Analysis functions accept 'glyexp' 'GlycomicSE', 'GlycoproteomicSE', and 'SummarizedExperiment' objects as their unified data interface.
 }
 \seealso{
 Useful links:

--- a/vignettes/glystats.Rmd
+++ b/vignettes/glystats.Rmd
@@ -20,11 +20,12 @@ PCA, survival analysis, and much more! 🧬
 `glystats` brings all these powerful analyses together under one unified,
 user-friendly interface.
 
-**🎯 Key Feature:** Every `glystats` analysis accepts a [glyexp::experiment()],
-the unified data interface at the heart of the `glycoverse` ecosystem 💓
+**🎯 Key Feature:** Every `glystats` analysis accepts
+[glyexp::GlycomicSE()] and [glyexp::GlycoproteomicSE()] containers,
+the unified data interfaces at the heart of the `glycoverse` ecosystem 💓
 
-New to [glyexp::experiment()]?
-No worries! Check out its [introduction](https://glycoverse.github.io/glyexp/articles/glyexp.html) first
+New to these containers?
+No worries! Check out the [glyexp introduction](https://glycoverse.github.io/glyexp/articles/glyexp.html) first
 to get up to speed.
 
 ```{r setup}
@@ -46,15 +47,12 @@ exp <- read_pglyco3_pglycoquant("glycopeptides.list", sample_info = "sample_info
 exp
 ```
 
-Look at that! 🎉 We've got a [glyexp::experiment()] packed with 12 samples and 263 glycoforms.
+Look at that! 🎉 We've got a [glyexp::GlycoproteomicSE()] packed with 12
+samples and 263 glycoforms.
 That's plenty of data to work with!
 
 ```{r}
-if (inherits(exp, "glyexp_experiment")) {
-  get_var_info(exp)
-} else {
-  tibble::as_tibble(rowData(exp), rownames = "variable")
-}
+tibble::as_tibble(rowData(exp), rownames = "variable")
 ```
 
 The variable information tibble is like a detailed ID card for each glycoform 🆔 -
@@ -62,11 +60,7 @@ it contains everything you need to know: the protein,
 glycosylation site, and glycan structures.
 
 ```{r}
-if (inherits(exp, "glyexp_experiment")) {
-  get_sample_info(exp)
-} else {
-  tibble::as_tibble(colData(exp), rownames = "sample")
-}
+tibble::as_tibble(colData(exp), rownames = "sample")
 ```
 
 Our sample information tibble features a crucial "group" column 🏷️.
@@ -165,7 +159,8 @@ Here's your complete toolkit for glycomics and glycoproteomics data analysis:
 Ready to dive deeper into the `glycoverse`? Here's your roadmap to success:
 
 1. **📥 Data Import:** Start with [glyread](https://glycoverse.github.io/glyread/articles/glyread.html)
-   to seamlessly import your data into `glyexp::experiment()` objects
+   to import your data into `glyexp::GlycomicSE` or
+   `glyexp::GlycoproteomicSE` objects
 
 2. **🧹 Data Preprocessing:** Use [glyclean](https://glycoverse.github.io/glyclean/articles/glyclean.html)
    to polish and prepare your data for analysis


### PR DESCRIPTION
Part of glycoverse/glyexp#15.

## Summary
- Recommend `GlycomicSE` and `GlycoproteomicSE` throughout documentation, README examples, and the vignette.
- Use `SummarizedExperiment` accessors and current row/column tidy verbs while retaining legacy runtime compatibility.
- Require `glyexp >= 0.16.0`.

## Verification
- `devtools::check()` — 0 errors, 0 warnings, 0 notes.
- Verified no standalone legacy `experiment()` constructor calls remain in public documentation.